### PR TITLE
Update Documentation

### DIFF
--- a/Sources/CardinalKitSecureStorage/CardinalKitSecureStorage.docc/CardinalKitSecureStorage.md
+++ b/Sources/CardinalKitSecureStorage/CardinalKitSecureStorage.docc/CardinalKitSecureStorage.md
@@ -1,4 +1,4 @@
-# ``SecureStorage``
+# ``CardinalKitSecureStorage``
 
 <!--
                   


### PR DESCRIPTION
# Update Documentation

## :recycle: Current situation & Problem
- The current DocC documentation for the secure storage module is not property tagged and therefore does not display it in the generated documentation in the Swift Package Index.

## :bulb: Proposed solution
- Adds a proper tag.

### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).

