### PR TITLE
Remove Unused Async Method Signatures

### DIFF
--- a/Sources/SpeziLocalStorage/LocalStorage.swift
+++ b/Sources/SpeziLocalStorage/LocalStorage.swift
@@ -52,7 +52,7 @@ public final class LocalStorage<ComponentStandard: Standard>: Module, DefaultIni
         _ element: C,
         storageKey: String? = nil,
         settings: LocalStorageSetting = .encryptedUsingKeyChain()
-    ) async throws {
+    ) throws {
         var fileURL = fileURL(from: storageKey, type: C.self)
         let fileExistsAlready = FileManager.default.fileExists(atPath: fileURL.path)
         
@@ -109,7 +109,7 @@ public final class LocalStorage<ComponentStandard: Standard>: Module, DefaultIni
         _ type: C.Type = C.self,
         storageKey: String? = nil,
         settings: LocalStorageSetting = .encryptedUsingKeyChain()
-    ) async throws -> C {
+    ) throws -> C {
         let fileURL = fileURL(from: storageKey, type: C.self)
         let data = try Data(contentsOf: fileURL)
         
@@ -134,22 +134,22 @@ public final class LocalStorage<ComponentStandard: Standard>: Module, DefaultIni
     /// Use ``LocalStorage/LocalStorage/delete(storageKey:)`` to deletes a file stored on disk identified by the `storageKey`.
     /// - Parameters:
     ///   - storageKey: An optional storage key to identify the file.
-    public func delete(storageKey: String) async throws {
-        try await delete(String.self, storageKey: storageKey)
+    public func delete(storageKey: String) throws {
+        try delete(String.self, storageKey: storageKey)
     }
     
     /// Use ``LocalStorage/LocalStorage/delete(storageKey:)`` to deletes a file stored on disk defined by a  `Decodable` type that is used to derive the storage key.
     /// - Parameters:
     ///   - type: The `Decodable` type that is used to derive the storage key from.
-    public func delete<C: Encodable>(_ type: C.Type = C.self) async throws {
-        try await delete(C.self, storageKey: nil)
+    public func delete<C: Encodable>(_ type: C.Type = C.self) throws {
+        try delete(C.self, storageKey: nil)
     }
     
     
     private func delete<C: Encodable>(
         _ type: C.Type = C.self,
         storageKey: String? = nil
-    ) async throws {
+    ) throws {
         let fileURL = self.fileURL(from: storageKey, type: C.self)
         
         if FileManager.default.fileExists(atPath: fileURL.path) {

--- a/Tests/SpeziLocalStorageTests/LocalStorageTests.swift
+++ b/Tests/SpeziLocalStorageTests/LocalStorageTests.swift
@@ -43,12 +43,12 @@ final class LocalStorageTests: XCTestCase {
         let localStorage = try XCTUnwrap(spezi.typedCollection[LocalStorage<LocalStorageTestStandard>.self])
         
         let letter = Letter(greeting: "Hello Paul 👋\(String(repeating: "🚀", count: Int.random(in: 0...10)))")
-        try await localStorage.store(letter, settings: .unencrypted())
-        let storedLetter: Letter = try await localStorage.read(settings: .unencrypted())
+        try localStorage.store(letter, settings: .unencrypted())
+        let storedLetter: Letter = try localStorage.read(settings: .unencrypted())
         
         XCTAssertEqual(letter, storedLetter)
         
-        try await localStorage.delete(Letter.self)
-        try await localStorage.delete(storageKey: "Letter")
+        try localStorage.delete(Letter.self)
+        try localStorage.delete(storageKey: "Letter")
     }
 }

--- a/Tests/UITests/TestApp/LocalStorageTests/LocalStorageTests.swift
+++ b/Tests/UITests/TestApp/LocalStorageTests/LocalStorageTests.swift
@@ -33,18 +33,18 @@ final class LocalStorageTests: TestAppTestCase {
     
     
     func runTests() async throws {
-        try await testLocalStorageTestEncryptedManualKeys()
+        try testLocalStorageTestEncryptedManualKeys()
         // Call test methods multiple times to test retrieval of keys.
-        try await testLocalStorageTestEncryptedKeychain()
-        try await testLocalStorageTestEncryptedKeychain()
+        try testLocalStorageTestEncryptedKeychain()
+        try testLocalStorageTestEncryptedKeychain()
         
         if SecureEnclave.isAvailable {
-            try await testLocalStorageTestEncryptedSecureEnclave()
-            try await testLocalStorageTestEncryptedSecureEnclave()
+            try testLocalStorageTestEncryptedSecureEnclave()
+            try testLocalStorageTestEncryptedSecureEnclave()
         }
     }
     
-    func testLocalStorageTestEncryptedManualKeys() async throws {
+    func testLocalStorageTestEncryptedManualKeys() throws {
         let privateKey = try secureStorage.retrievePrivateKey(forTag: "LocalStorageTests") ?? secureStorage.createKey("LocalStorageTests")
         guard let publicKey = try secureStorage.retrievePublicKey(forTag: "LocalStorageTests") else {
             throw XCTestFailure()
@@ -52,26 +52,26 @@ final class LocalStorageTests: TestAppTestCase {
         
         let letter = Letter(greeting: "Hello Paul 👋\(String(repeating: "🚀", count: Int.random(in: 0...10)))")
         
-        try await localStorage.store(letter, settings: .encrypted(privateKey: privateKey, publicKey: publicKey))
-        let storedLetter: Letter = try await localStorage.read(settings: .encrypted(privateKey: privateKey, publicKey: publicKey))
+        try localStorage.store(letter, settings: .encrypted(privateKey: privateKey, publicKey: publicKey))
+        let storedLetter: Letter = try localStorage.read(settings: .encrypted(privateKey: privateKey, publicKey: publicKey))
         
         try XCTAssertEqual(letter, storedLetter)
     }
     
-    func testLocalStorageTestEncryptedKeychain() async throws {
+    func testLocalStorageTestEncryptedKeychain() throws {
         let letter = Letter(greeting: "Hello Paul 👋\(String(repeating: "🚀", count: Int.random(in: 0...10)))")
 
-        try await localStorage.store(letter, settings: .encryptedUsingKeyChain())
-        let storedLetter: Letter = try await localStorage.read(settings: .encryptedUsingKeyChain())
+        try localStorage.store(letter, settings: .encryptedUsingKeyChain())
+        let storedLetter: Letter = try localStorage.read(settings: .encryptedUsingKeyChain())
 
         try XCTAssertEqual(letter, storedLetter)
     }
 
-    func testLocalStorageTestEncryptedSecureEnclave() async throws {
+    func testLocalStorageTestEncryptedSecureEnclave() throws {
         let letter = Letter(greeting: "Hello Paul 👋\(String(repeating: "🚀", count: Int.random(in: 0...10)))")
         
-        try await localStorage.store(letter, settings: .encryptedUsingSecureEnclave())
-        let storedLetter: Letter = try await localStorage.read(settings: .encryptedUsingSecureEnclave())
+        try localStorage.store(letter, settings: .encryptedUsingSecureEnclave())
+        let storedLetter: Letter = try localStorage.read(settings: .encryptedUsingSecureEnclave())
         
         try XCTAssertEqual(letter, storedLetter)
     }


### PR DESCRIPTION
# Remove Unused Async Method Signatures

## :recycle: Current situation & Problem
- The current method overloads in the storage module are not using any async functionality.

## :bulb: Proposed solution
- This PR removes the async overloads.

### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
