### PR TITLE
Fix Swift Package Resolution Error

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -22,7 +22,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/StanfordSpezi/Spezi", .upToNextMinor(from: "0.7.0")),
-        .package(url: "https://github.com/StanfordSpezi/XCTRuntimeAssertions", .upToNextMinor(from: "0.2.2"))
+        .package(url: "https://github.com/StanfordBDHG/XCTRuntimeAssertions", .upToNextMinor(from: "0.2.5"))
     ],
     targets: [
         .target(


### PR DESCRIPTION
# Fix Swift Package Resolution Error

## :recycle: Current situation & Problem
- When using the package, users get the following warning: `'spezistorage' dependency on 'https://github.com/StanfordSpezi/XCTRuntimeAssertions' conflicts with dependency on 'https://github.com/StanfordBDHG/XCTRuntimeAssertions' which has the same identity 'xctruntimeassertions'. this will be escalated to an error in future versions of SwiftPM.`

## :bulb: Proposed solution
- Fixes the issue by using the correct path at `https://github.com/StanfordBDHG/XCTRuntimeAssertions`.


### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
