### PR TITLE
Delete Secure Storage & Improve Getting and Loading Credentials

### DIFF
--- a/Sources/SpeziSecureStorage/SecureStorageItemTypes.swift
+++ b/Sources/SpeziSecureStorage/SecureStorageItemTypes.swift
@@ -1,0 +1,48 @@
+//
+// This source file is part of the Stanford Spezi open-source project
+//
+// SPDX-FileCopyrightText: 2022 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+import Security
+
+
+/// Types of items that can be stored in the secure storage.
+public struct SecureStorageItemTypes: OptionSet {
+    /// Keys as created with (``SecureStorage/createKey(_:size:storageScope:)``).
+    public static let keys = SecureStorageItemTypes(rawValue: 1 << 0)
+    /// Credentials as created with (``SecureStorage/store(credentials:server:removeDuplicate:storageScope:)``) by passing in a server name.
+    public static let serverCredentials = SecureStorageItemTypes(rawValue: 1 << 1)
+    /// Credentials as created with (``SecureStorage/store(credentials:server:removeDuplicate:storageScope:)``) by omitting a server name.
+    public static let nonServerCredentials = SecureStorageItemTypes(rawValue: 1 << 2)
+    
+    /// Credentials as created with (``SecureStorage/store(credentials:server:removeDuplicate:storageScope:)``).
+    public static let credentials: SecureStorageItemTypes = [.serverCredentials, .serverCredentials]
+    /// All types of items that can be handled by the secure storage component.
+    public static let all: SecureStorageItemTypes = [.keys, .serverCredentials, .nonServerCredentials]
+    
+    
+    public let rawValue: Int
+    
+    
+    var kSecClass: [CFString] {
+        var kSecClass: [CFString] = []
+        if self.contains(.keys) {
+            kSecClass.append(kSecClassKey)
+        }
+        if self.contains(.serverCredentials) {
+            kSecClass.append(kSecClassGenericPassword)
+        }
+        if self.contains(.nonServerCredentials) {
+            kSecClass.append(kSecClassInternetPassword)
+        }
+        return kSecClass
+    }
+    
+    
+    public init(rawValue: Int) {
+        self.rawValue = rawValue
+    }
+}

--- a/Tests/UITests/UITests.xcodeproj/xcshareddata/xcschemes/TestApp.xcscheme
+++ b/Tests/UITests/UITests.xcodeproj/xcshareddata/xcschemes/TestApp.xcscheme
@@ -57,7 +57,8 @@
       shouldUseLaunchSchemeArgsEnv = "YES">
       <TestPlans>
          <TestPlanReference
-            reference = "container:TestApp.xctestplan">
+            reference = "container:TestApp.xctestplan"
+            default = "YES">
          </TestPlanReference>
       </TestPlans>
       <Testables>


### PR DESCRIPTION
# Delete Secure Storage & Improve Getting and Loading Credentials

## :recycle: Current situation & Problem
- The API currently does not provide a functionality to retrieve all credentials for a web service or generally stored credentials.
- There is no API to delete credentials.


## :gear: Release Notes 
- Provides an API endpoint to retrieve all credentials and filter by server.
- Adds a mechanism to delete credentials.


## :books: Documentation
- Added documentation and additional context.


## :white_check_mark: Testing
- Added tests for all new functions.


## :pencil: Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
