### PR TITLE
Make `LocalStorage` and `SecureStorage` Sendable

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,8 +76,8 @@ The [`LocalStorage`](https://swiftpackageindex.com/stanfordspezi/spezistorage/do
 The [`LocalStorage`](https://swiftpackageindex.com/stanfordspezi/spezistorage/documentation/spezilocalstorage/localstorage) module defaults to storing data encrypted supported by the [`SecureStorage`](https://swiftpackageindex.com/StanfordSpezi/SpeziStorage/documentation/spezisecurestorage) module.
 The [`LocalStorageSetting`](https://swiftpackageindex.com/stanfordspezi/spezistorage/documentation/spezilocalstorage/localstoragesetting) enables configuring how data in the [`LocalStorage`](https://swiftpackageindex.com/stanfordspezi/spezistorage/documentation/spezilocalstorage/localstorage) module can be stored and retrieved.
 
-- Store or update new elements: [`store(_:storageKey:settings:)`](https://swiftpackageindex.com/stanfordspezi/spezistorage/documentation/spezilocalstorage/localstorage/store(_:storagekey:settings:))
-- Retrieve existing elements: [`read(_:storageKey:settings:)`](https://swiftpackageindex.com/stanfordspezi/spezistorage/documentation/spezilocalstorage/localstorage/read(_:storagekey:settings:))
+- Store or update new elements: [`store(_:encoder:storageKey:settings:)`](https://swiftpackageindex.com/stanfordspezi/spezistorage/documentation/spezilocalstorage/localstorage/store(_:encoder:storagekey:settings:))
+- Retrieve existing elements: [`read(_:decoder:storageKey:settings:)`](https://swiftpackageindex.com/stanfordspezi/spezistorage/documentation/spezilocalstorage/localstorage/read(_:decoder:storagekey:settings:))
 - Delete existing elements: [`delete(_:)`](https://swiftpackageindex.com/stanfordspezi/spezistorage/documentation/spezilocalstorage/localstorage/delete(_:))
 
 

--- a/Sources/SpeziLocalStorage/LocalStorage.swift
+++ b/Sources/SpeziLocalStorage/LocalStorage.swift
@@ -21,7 +21,7 @@ import SpeziSecureStorage
 /// Use ``LocalStorage/store(_:storageKey:settings:)`` to store elements on disk and define the settings using a ``LocalStorageSetting`` instance.
 ///
 /// Use ``LocalStorage/read(_:storageKey:settings:)`` to read elements on disk which are decoded as define by  passed in  ``LocalStorageSetting`` instance.
-public final class LocalStorage: Module, DefaultInitializable, EnvironmentAccessible {
+public final class LocalStorage: Module, DefaultInitializable, EnvironmentAccessible, @unchecked Sendable {
     private let encryptionAlgorithm: SecKeyAlgorithm = .eciesEncryptionCofactorX963SHA256AESGCM
     @Dependency private var secureStorage = SecureStorage()
     

--- a/Sources/SpeziLocalStorage/LocalStorage.swift
+++ b/Sources/SpeziLocalStorage/LocalStorage.swift
@@ -18,9 +18,9 @@ import SpeziSecureStorage
 /// The module relies on the [`SecureStorage`](https://swiftpackageindex.com/StanfordSpezi/SpeziStorage/documentation/spezisecurestorage)
 /// module to enable an encrypted on-disk storage as defined by the ``LocalStorageSetting`` configuration.
 ///
-/// Use ``LocalStorage/store(_:storageKey:settings:)`` to store elements on disk and define the settings using a ``LocalStorageSetting`` instance.
+/// Use ``store(_:encoder:storageKey:settings:)`` to store elements on disk and define the settings using a `LocalStorageSetting` instance.
 ///
-/// Use ``LocalStorage/read(_:storageKey:settings:)`` to read elements on disk which are decoded as define by  passed in  ``LocalStorageSetting`` instance.
+/// Use ``read(_:decoder:storageKey:settings:)`` to read elements on disk which are decoded as define by  passed in  `LocalStorageSetting` instance.
 public final class LocalStorage: Module, DefaultInitializable, EnvironmentAccessible, @unchecked Sendable {
     private let encryptionAlgorithm: SecKeyAlgorithm = .eciesEncryptionCofactorX963SHA256AESGCM
     @Dependency private var secureStorage = SecureStorage()

--- a/Sources/SpeziSecureStorage/SecureStorage.swift
+++ b/Sources/SpeziSecureStorage/SecureStorage.swift
@@ -20,7 +20,7 @@ import XCTRuntimeAssertions
 /// [Using the keychain to manage user secrets](https://developer.apple.com/documentation/security/keychain_services/keychain_items/using_the_keychain_to_manage_user_secrets).
 ///
 /// On the macOS platform, the ``SecureStorage`` uses the [Data protection keychain](https://developer.apple.com/documentation/technotes/tn3137-on-mac-keychains) which mirrors the data protection keychain originated on iOS.
-public final class SecureStorage: Module, DefaultInitializable, EnvironmentAccessible {
+public final class SecureStorage: Module, DefaultInitializable, EnvironmentAccessible, Sendable {
     /// The ``SecureStorage`` serves as a reusable `Module` that can be used to store store small chunks of data such as credentials and keys.
     ///
     /// The storing of credentials and keys follows the Keychain documentation provided by Apple:

--- a/Sources/SpeziSecureStorage/SecureStorage.swift
+++ b/Sources/SpeziSecureStorage/SecureStorage.swift
@@ -19,7 +19,7 @@ import XCTRuntimeAssertions
 /// The storing of credentials and keys follows the Keychain documentation provided by Apple: 
 /// [Using the keychain to manage user secrets](https://developer.apple.com/documentation/security/keychain_services/keychain_items/using_the_keychain_to_manage_user_secrets).
 ///
-/// On the macOS platform, the ``SecureStorage`` uses the [Data protection keychain](https://developer.apple.com/documentation/technotes/tn3137-on-mac-keychains) which mirrors the data protection keychain originated on iOS.
+/// On the macOS platform, the `SecureStorage` uses the [Data protection keychain](https://developer.apple.com/documentation/technotes/tn3137-on-mac-keychains) which mirrors the data protection keychain originated on iOS.
 public final class SecureStorage: Module, DefaultInitializable, EnvironmentAccessible, Sendable {
     /// The ``SecureStorage`` serves as a reusable `Module` that can be used to store store small chunks of data such as credentials and keys.
     ///
@@ -230,6 +230,7 @@ public final class SecureStorage: Module, DefaultInitializable, EnvironmentAcces
     
     /// Delete all existing credentials stored in the Keychain.
     /// - Parameters:
+    ///   - itemTypes: The types of items.
     ///   - accessGroup: The access group associated with the credentials.
     public func deleteAllCredentials(itemTypes: SecureStorageItemTypes = .all, accessGroup: String? = nil) throws {
         for kSecClassType in itemTypes.kSecClass {

--- a/Sources/SpeziSecureStorage/SecureStorageItemTypes.swift
+++ b/Sources/SpeziSecureStorage/SecureStorageItemTypes.swift
@@ -19,7 +19,7 @@ public struct SecureStorageItemTypes: OptionSet {
     public static let nonServerCredentials = SecureStorageItemTypes(rawValue: 1 << 2)
     
     /// Credentials as created with (``SecureStorage/store(credentials:server:removeDuplicate:storageScope:)``).
-    public static let credentials: SecureStorageItemTypes = [.serverCredentials, .serverCredentials]
+    public static let credentials: SecureStorageItemTypes = [.serverCredentials, .nonServerCredentials]
     /// All types of items that can be handled by the secure storage component.
     public static let all: SecureStorageItemTypes = [.keys, .serverCredentials, .nonServerCredentials]
     


### PR DESCRIPTION
# Make `LocalStorage` and `SecureStorage` Sendable

## :recycle: Current situation & Problem
This PR adds `Sendable` conformance for both storage modules.


## :gear: Release Notes 
* `LocalStorage` is now `Sendable`
* `SecureStorage` is now `Sendable`


## :books: Documentation
--


## :white_check_mark: Testing
--

## :pencil: Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
