### PR TITLE
Fix using supplied decoder for encrypted values

### DIFF
--- a/Sources/SpeziLocalStorage/LocalStorage.swift
+++ b/Sources/SpeziLocalStorage/LocalStorage.swift
@@ -161,7 +161,7 @@ public final class LocalStorage: Module, DefaultInitializable, EnvironmentAccess
             throw LocalStorageError.decryptionNotPossible
         }
         
-        return try JSONDecoder().decode(C.self, from: decryptedData)
+        return try decoder.decode(C.self, from: decryptedData)
     }
     
     


### PR DESCRIPTION
# Fix using supplied decoder for encrypted values

## :recycle: Current situation & Problem
There was an issue in the `read` implementation where the supplied `decoder` was only used if the element wasn't encrypted. The other code path was forgotten to be updated in #21.
This issue is fixed by this PR. 

## :gear: Release Notes 
* Fixed an issue where the supplied decoder wasn't used.


## :books: Documentation
--


## :white_check_mark: Testing
--


## :pencil: Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
