### PR TITLE
Support CodableWithConfiguration when storing and retrieving from LocalStorage

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -31,9 +31,9 @@ let package = Package(
         .library(name: "SpeziSecureStorage", targets: ["SpeziSecureStorage"])
     ],
     dependencies: [
-        .package(url: "https://github.com/StanfordSpezi/Spezi", from: "1.2.1"),
-        .package(url: "https://github.com/StanfordSpezi/SpeziFoundation", branch: "feature/encoder-decoder-protocols"),
-        .package(url: "https://github.com/StanfordBDHG/XCTRuntimeAssertions", from: "1.0.1")
+        .package(url: "https://github.com/StanfordSpezi/Spezi", from: "1.7.3"),
+        .package(url: "https://github.com/StanfordSpezi/SpeziFoundation", from: "2.0.0-beta.2"),
+        .package(url: "https://github.com/StanfordBDHG/XCTRuntimeAssertions", from: "1.1.1")
     ] + swiftLintPackage(),
     targets: [
         .target(

--- a/Package.swift
+++ b/Package.swift
@@ -32,6 +32,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/StanfordSpezi/Spezi", from: "1.2.1"),
+        .package(url: "https://github.com/StanfordSpezi/SpeziFoundation", branch: "feature/encoder-decoder-protocols"),
         .package(url: "https://github.com/StanfordBDHG/XCTRuntimeAssertions", from: "1.0.1")
     ] + swiftLintPackage(),
     targets: [
@@ -39,6 +40,7 @@ let package = Package(
             name: "SpeziLocalStorage",
             dependencies: [
                 .product(name: "Spezi", package: "Spezi"),
+                .product(name: "SpeziFoundation", package: "SpeziFoundation"),
                 .target(name: "SpeziSecureStorage")
             ],
             swiftSettings: [
@@ -83,7 +85,7 @@ func swiftLintPlugin() -> [Target.PluginUsage] {
 
 func swiftLintPackage() -> [PackageDescription.Package.Dependency] {
     if ProcessInfo.processInfo.environment["SPEZI_DEVELOPMENT_SWIFTLINT"] != nil {
-        [.package(url: "https://github.com/realm/SwiftLint.git", .upToNextMinor(from: "0.55.1"))]
+        [.package(url: "https://github.com/realm/SwiftLint.git", from: "0.55.1")]
     } else {
         []
     }

--- a/README.md
+++ b/README.md
@@ -30,10 +30,10 @@ You need to add the Spezi Storage Swift package to
 > [!IMPORTANT]
 > If your application is not yet configured to use Spezi, follow the [Spezi setup article](https://swiftpackageindex.com/stanfordspezi/spezi/documentation/spezi/initial-setup) to set up the core Spezi infrastructure.
 
+You can configure the [`LocalStorage`](https://swiftpackageindex.com/stanfordspezi/spezistorage/documentation/spezilocalstorage/localstorage) or [`SecureStorage`](https://swiftpackageindex.com/StanfordSpezi/SpeziStorage/documentation/spezisecurestorage) module in the [`SpeziAppDelegate`](https://swiftpackageindex.com/stanfordspezi/spezi/documentation/spezi/speziappdelegate).
+
 > [!IMPORTANT]
 > If you use SpeziStorage on the macOS platform, ensure to add the [`Keychain Access Groups` entitlement](https://developer.apple.com/documentation/bundleresources/entitlements/keychain-access-groups) to the enclosing Xcode project via *PROJECT_NAME > Signing&Capabilities > + Capability*. The array of keychain groups can be left empty, only the base entitlement is required.
-
-You can configure the [`LocalStorage`](https://swiftpackageindex.com/stanfordspezi/spezistorage/documentation/spezilocalstorage/localstorage) or [`SecureStorage`](https://swiftpackageindex.com/StanfordSpezi/SpeziStorage/documentation/spezisecurestorage) module in the [`SpeziAppDelegate`](https://swiftpackageindex.com/stanfordspezi/spezi/documentation/spezi/speziappdelegate).
 
 ```swift
 import Spezi
@@ -52,7 +52,7 @@ class ExampleDelegate: SpeziAppDelegate {
 }
 ```
 
-You can then use the [`LocalStorage`](https://swiftpackageindex.com/stanfordspezi/spezistorage/documentation/spezilocalstorage/localstorage) or [`SecureStorage`](https://swiftpackageindex.com/StanfordSpezi/SpeziStorage/documentation/spezisecurestorage) class in any SwiftUI view.
+You can then use the `LocalStorage` or `SecureStorage` class in any SwiftUI view.
 
 ```swift
 struct ExampleStorageView: View {
@@ -66,15 +66,15 @@ struct ExampleStorageView: View {
 }
 ```
 
-Alternatively, it is common to use the [`LocalStorage`](https://swiftpackageindex.com/stanfordspezi/spezistorage/documentation/spezilocalstorage/localstorage) or [`SecureStorage`](https://swiftpackageindex.com/StanfordSpezi/SpeziStorage/documentation/spezisecurestorage) module in other modules as a dependency: [Spezi Module dependencies](https://swiftpackageindex.com/stanfordspezi/spezi/documentation/spezi/module-dependency).
+Alternatively, it is common to use the `LocalStorage` or `SecureStorage` module in other modules as a dependency: [Spezi Module dependencies](https://swiftpackageindex.com/stanfordspezi/spezi/documentation/spezi/module-dependency).
 
 
 ## Local Storage
 
-The [`LocalStorage`](https://swiftpackageindex.com/stanfordspezi/spezistorage/documentation/spezilocalstorage/localstorage) module enables the on-disk storage of data in mobile applications.
+The `LocalStorage` module enables the on-disk storage of data in mobile applications.
 
-The [`LocalStorage`](https://swiftpackageindex.com/stanfordspezi/spezistorage/documentation/spezilocalstorage/localstorage) module defaults to storing data encrypted supported by the [`SecureStorage`](https://swiftpackageindex.com/StanfordSpezi/SpeziStorage/documentation/spezisecurestorage) module.
-The [`LocalStorageSetting`](https://swiftpackageindex.com/stanfordspezi/spezistorage/documentation/spezilocalstorage/localstoragesetting) enables configuring how data in the [`LocalStorage`](https://swiftpackageindex.com/stanfordspezi/spezistorage/documentation/spezilocalstorage/localstorage) module can be stored and retrieved.
+The `LocalStorage` module defaults to storing data encrypted supported by the `SecureStorage` module.
+The [`LocalStorageSetting`](https://swiftpackageindex.com/stanfordspezi/spezistorage/documentation/spezilocalstorage/localstoragesetting) enables configuring how data in the `LocalStorage` module can be stored and retrieved.
 
 - Store or update new elements: [`store(_:encoder:storageKey:settings:)`](https://swiftpackageindex.com/stanfordspezi/spezistorage/documentation/spezilocalstorage/localstorage/store(_:encoder:storagekey:settings:))
 - Retrieve existing elements: [`read(_:decoder:storageKey:settings:)`](https://swiftpackageindex.com/stanfordspezi/spezistorage/documentation/spezilocalstorage/localstorage/read(_:decoder:storagekey:settings:))
@@ -83,13 +83,13 @@ The [`LocalStorageSetting`](https://swiftpackageindex.com/stanfordspezi/spezisto
 
 ## Secure Storage
 
-The [`SecureStorage`](https://swiftpackageindex.com/StanfordSpezi/SpeziStorage/documentation/spezisecurestorage) module allows for the encrypted storage of small chunks of sensitive user data, such as usernames and passwords for internet services, using Apple's [Keychain documentation](https://developer.apple.com/documentation/security/keychain_services/keychain_items/using_the_keychain_to_manage_user_secrets). 
+The `SecureStorage` module allows for the encrypted storage of small chunks of sensitive user data, such as usernames and passwords for internet services, using Apple's [Keychain documentation](https://developer.apple.com/documentation/security/keychain_services/keychain_items/using_the_keychain_to_manage_user_secrets). 
 
 Credentials can be stored in the Secure Enclave (if available) or the Keychain. Credentials stored in the Keychain can be made synchronizable between different instances of user devices.
 
 ### Handling Credentials
 
-Use the [`SecureStorage`](https://swiftpackageindex.com/StanfordSpezi/SpeziStorage/documentation/spezisecurestorage) module to store a set of [`Credentials`](https://swiftpackageindex.com/stanfordspezi/spezistorage/documentation/spezisecurestorage/credentials) instances in the Keychain associated with a server that is synchronizable between different devices.
+Use the `SecureStorage` module to store a set of [`Credentials`](https://swiftpackageindex.com/stanfordspezi/spezistorage/documentation/spezisecurestorage/credentials) instances in the Keychain associated with a server that is synchronizable between different devices.
 
 - Store new credentials: [`store(credentials:server:removeDuplicate:storageScope:)`](https://swiftpackageindex.com/stanfordspezi/spezistorage/documentation/spezisecurestorage/securestorage/store(credentials:server:removeduplicate:storagescope:))
 - Retrieve existing credentials: [`retrieveCredentials(_:server:accessGroup:)`](https://swiftpackageindex.com/stanfordspezi/spezistorage/documentation/spezisecurestorage/securestorage/retrievecredentials(_:server:accessgroup:))
@@ -101,7 +101,7 @@ Use the [`SecureStorage`](https://swiftpackageindex.com/StanfordSpezi/SpeziStora
 
 ### Handling Keys
 
-Similar to [`Credentials`](https://swiftpackageindex.com/stanfordspezi/spezistorage/documentation/spezisecurestorage/credentials) instances, you can also use the [`SecureStorage`](https://swiftpackageindex.com/StanfordSpezi/SpeziStorage/documentation/spezisecurestorage) module to interact with keys.
+Similar to `Credentials` instances, you can also use the `SecureStorage` module to interact with keys.
 
 - Create new keys: [`createKey(_:size:storageScope:)`](https://swiftpackageindex.com/stanfordspezi/spezistorage/documentation/spezisecurestorage/securestorage/createkey(_:size:storagescope:))
 - Retrieve existing public keys: [`retrievePublicKey(forTag:)`](https://swiftpackageindex.com/stanfordspezi/spezistorage/documentation/spezisecurestorage/securestorage/retrievepublickey(fortag:))

--- a/Sources/SpeziLocalStorage/LocalStorage.swift
+++ b/Sources/SpeziLocalStorage/LocalStorage.swift
@@ -204,7 +204,7 @@ public final class LocalStorage: Module, DefaultInitializable, EnvironmentAccess
     ///   - storageKey: An optional storage key to identify the file.
     ///   - settings: The ``LocalStorageSetting``s used to retrieve the file on disk.
     /// - Returns: The element conforming to `Decodable`.
-    public func read<C: DecodableWithConfiguration, D: TopLevelDecoder>(
+    public func read<C: DecodableWithConfiguration, D: TopLevelDecoder>( // swiftlint:disable:this function_default_parameter_at_end
         _ type: C.Type = C.self,
         configuration: C.DecodingConfiguration,
         decoder: D = JSONDecoder(),

--- a/Sources/SpeziLocalStorage/LocalStorageError.swift
+++ b/Sources/SpeziLocalStorage/LocalStorageError.swift
@@ -7,7 +7,7 @@
 //
 
 
-/// An error thrown by the ``LocalStorage`` module.
+/// An error thrown by the `LocalStorage` module.
 enum LocalStorageError: Error {
     /// Encryption of the file was not possible, did not store the data on disk.
     case encryptionNotPossible

--- a/Sources/SpeziLocalStorage/LocalStorageSetting.swift
+++ b/Sources/SpeziLocalStorage/LocalStorageSetting.swift
@@ -11,7 +11,7 @@ import Spezi
 import SpeziSecureStorage
 
 
-/// Configure how data in the ``LocalStorage`` module can be stored and retrieved.
+/// Configure how data can be stored and retrieved.
 public enum LocalStorageSetting {
     /// Unencrypted
     case unencrypted(excludedFromBackup: Bool = true)

--- a/Sources/SpeziLocalStorage/SpeziLocalStorage.docc/SpeziLocalStorage.md
+++ b/Sources/SpeziLocalStorage/SpeziLocalStorage.docc/SpeziLocalStorage.md
@@ -28,9 +28,9 @@ You need to add the Spezi Storage Swift package to
 
 > Important: If your application is not yet configured to use Spezi, follow the [Spezi setup article](https://swiftpackageindex.com/stanfordspezi/spezi/documentation/spezi/initial-setup) to set up the core Spezi infrastructure.
 
-> Important: If you use the ``LocalStorage`` on the macOS platform, ensure to add the [`Keychain Access Groups` entitlement](https://developer.apple.com/documentation/bundleresources/entitlements/keychain-access-groups) to the enclosing Xcode project via *PROJECT_NAME > Signing&Capabilities > + Capability*. The array of keychain groups can be left empty, only the base entitlement is required.
-
 You can configure the `LocalStorage` module in the [`SpeziAppDelegate`](https://swiftpackageindex.com/stanfordspezi/spezi/documentation/spezi/speziappdelegate).
+
+> Important: If you use the ``LocalStorage`` on the macOS platform, ensure to add the [`Keychain Access Groups` entitlement](https://developer.apple.com/documentation/bundleresources/entitlements/keychain-access-groups) to the enclosing Xcode project via *PROJECT_NAME > Signing&Capabilities > + Capability*. The array of keychain groups can be left empty, only the base entitlement is required.
 
 ```swift
 import Spezi
@@ -47,7 +47,7 @@ class ExampleDelegate: SpeziAppDelegate {
 }
 ```
 
-You can then use the ``LocalStorage`` class in any SwiftUI view.
+You can then use the `LocalStorage` module in any SwiftUI view.
 
 ```swift
 struct ExampleStorageView: View {
@@ -59,17 +59,17 @@ struct ExampleStorageView: View {
 }
 ```
 
-Alternatively, it is common to use the ``LocalStorage`` module in other modules as a dependency: [Spezi Module dependencies](https://swiftpackageindex.com/stanfordspezi/spezi/documentation/spezi/module-dependency).
+Alternatively, it is common to use the `LocalStorage` module in other modules as a dependency: [Spezi Module dependencies](https://swiftpackageindex.com/stanfordspezi/spezi/documentation/spezi/module-dependency).
 
 
 ## Use the LocalStorage Module
 
-You can use the ``LocalStorage`` module to store, update, retrieve, and delete element conforming to [`Codable`](https://developer.apple.com/documentation/swift/codable). 
+You can use the `LocalStorage` module to store, update, retrieve, and delete element conforming to [`Codable`](https://developer.apple.com/documentation/swift/codable). 
 
 
 ### Storing & Update Data
 
-The ``LocalStorage`` module enables the storage and update of elements conforming to [`Codable`](https://developer.apple.com/documentation/swift/codable).
+The `LocalStorage` module enables the storage and update of elements conforming to `Codable`.
 
 ```swift
 struct Note: Codable, Equatable {
@@ -86,13 +86,13 @@ do {
 }
 ```
 
-See ``LocalStorage/store(_:storageKey:settings:)`` for more details.
+See ``LocalStorage/store(_:encoder:storageKey:settings:)`` for more details.
 
 
 
 ### Read Data
 
-The ``LocalStorage`` module enables the retrieval of elements conforming to [`Codable`](https://developer.apple.com/documentation/swift/codable).
+The `LocalStorage` module enables the retrieval of elements conforming to [`Codable`](https://developer.apple.com/documentation/swift/codable).
 
 ```swift
 do {
@@ -103,12 +103,12 @@ do {
 }
 ```
 
-See ``LocalStorage/read(_:storageKey:settings:)`` for more details.
+See ``LocalStorage/read(_:decoder:storageKey:settings:)`` for more details.
 
 
 ### Deleting Element
 
-The ``LocalStorage`` module enables the deletion of a previously stored elements.
+The `LocalStorage` module enables the deletion of a previously stored elements.
 
 ```swift
 do {
@@ -127,8 +127,4 @@ See ``LocalStorage/delete(_:)`` or ``LocalStorage/delete(storageKey:)`` for more
 
 - ``LocalStorage``
 - ``LocalStorageSetting``
-- ``LocalStorage/store(_:storageKey:settings:)``
-- ``LocalStorage/read(_:storageKey:settings:)``
-- ``LocalStorage/delete(storageKey:)``
-- ``LocalStorage/delete(_:)``
 

--- a/Sources/SpeziSecureStorage/Credentials.swift
+++ b/Sources/SpeziSecureStorage/Credentials.swift
@@ -7,24 +7,24 @@
 //
 
 
-/// Credentials that can be stored, updated, deleted, and retrieved from a ``SecureStorage`` module.
+/// A pair of username and password credentials.
 public struct Credentials: Equatable, Identifiable {
-    /// The username
+    /// The username.
     public var username: String
-    /// The password associated to the ``Credentials/username``
+    /// The password.
     public var password: String
     
     
-    /// Identifier of the ``Credentials`` representing the ``Credentials/username``
+    /// Identified by the username.
     public var id: String {
         username
     }
     
     
-    /// Credentials that can be stored, updated, deleted, and retrieved from a ``SecureStorage`` module.
+    /// Create new credentials.
     /// - Parameters:
-    ///   - username: The username
-    ///   - password: The password associated to the ``Credentials/username``
+    ///   - username: The username.
+    ///   - password: The password.
     public init(username: String, password: String) {
         self.username = username
         self.password = password

--- a/Sources/SpeziSecureStorage/SecureStorage.swift
+++ b/Sources/SpeziSecureStorage/SecureStorage.swift
@@ -20,10 +20,32 @@ import XCTRuntimeAssertions
 /// [Using the keychain to manage user secrets](https://developer.apple.com/documentation/security/keychain_services/keychain_items/using_the_keychain_to_manage_user_secrets).
 ///
 /// On the macOS platform, the `SecureStorage` uses the [Data protection keychain](https://developer.apple.com/documentation/technotes/tn3137-on-mac-keychains) which mirrors the data protection keychain originated on iOS.
+///
+/// ## Topics
+/// ### Configuration
+/// - ``init()``
+///
+/// ### Credentials
+/// - ``Credentials``
+/// - ``store(credentials:server:removeDuplicate:storageScope:)``
+/// - ``retrieveCredentials(_:server:accessGroup:)``
+/// - ``retrieveAllCredentials(forServer:accessGroup:)``
+/// - ``updateCredentials(_:server:newCredentials:newServer:removeDuplicate:storageScope:)``
+/// - ``deleteCredentials(_:server:accessGroup:)``
+/// - ``deleteAllCredentials(itemTypes:accessGroup:)``
+///
+/// ### Keys
+///
+/// - ``createKey(_:size:storageScope:)``
+/// - ``retrievePublicKey(forTag:)``
+/// - ``retrievePrivateKey(forTag:)``
+/// - ``deleteKeys(forTag:)``
 public final class SecureStorage: Module, DefaultInitializable, EnvironmentAccessible, Sendable {
-    /// The ``SecureStorage`` serves as a reusable `Module` that can be used to store store small chunks of data such as credentials and keys.
+    /// Configure the SecureStorage module.
     ///
-    /// The storing of credentials and keys follows the Keychain documentation provided by Apple:
+    /// The `SecureStorage` serves as a reusable `Module` that can be used to store store small chunks of data such as credentials and keys.
+    ///
+    /// - Note: The storing of credentials and keys follows the Keychain documentation provided by Apple:
     /// [Using the keychain to manage user secrets](https://developer.apple.com/documentation/security/keychain_services/keychain_items/using_the_keychain_to_manage_user_secrets).
     public required init() {}
     

--- a/Sources/SpeziSecureStorage/SecureStorageError.swift
+++ b/Sources/SpeziSecureStorage/SecureStorageError.swift
@@ -10,7 +10,7 @@ import CryptoKit
 import Security
 
 
-/// An `Error` thrown by the ``SecureStorage`` module.
+/// An `Error` thrown by the `SecureStorage` module.
 public enum SecureStorageError: Error {
     /// Creation of a new element failed with a `CFError`.
     case createFailed(CFError? = nil)
@@ -26,8 +26,8 @@ public enum SecureStorageError: Error {
     /// for more information about KeyChain access groups.
     /// Remove the  ``SecureStorageScope``'s `accessGroup` configuration value if you do not intend to use KeyChain access groups.
     case missingEntitlement
-    /// The ``SecureStorage`` is unable to decode the information obtained into a credentials.
+    /// The `SecureStorage` module is unable to decode the information obtained into a credentials.
     case unexpectedCredentialsData
-    /// The ``SecureStorage`` encountered a Keychain error when interacting with the Keychain.
+    /// The `SecureStorage` module encountered a Keychain error when interacting with the Keychain.
     case keychainError(status: OSStatus)
 }

--- a/Sources/SpeziSecureStorage/SecureStorageItemTypes.swift
+++ b/Sources/SpeziSecureStorage/SecureStorageItemTypes.swift
@@ -11,14 +11,22 @@ import Security
 
 /// Types of items that can be stored in the secure storage.
 public struct SecureStorageItemTypes: OptionSet {
-    /// Keys as created with (``SecureStorage/createKey(_:size:storageScope:)``).
+    /// Any keys created with the `SecureStorage` module.
+    ///
+    /// Refers to any keys created using ``SecureStorage/createKey(_:size:storageScope:)``.
     public static let keys = SecureStorageItemTypes(rawValue: 1 << 0)
-    /// Credentials as created with (``SecureStorage/store(credentials:server:removeDuplicate:storageScope:)``) by passing in a server name.
+    /// Credentials that are created using a server name.
+    ///
+    /// Refers to any credentials that are stored using a server name using ``SecureStorage/store(credentials:server:removeDuplicate:storageScope:)``.
     public static let serverCredentials = SecureStorageItemTypes(rawValue: 1 << 1)
-    /// Credentials as created with (``SecureStorage/store(credentials:server:removeDuplicate:storageScope:)``) by omitting a server name.
+    /// Credentials that are created without supplying a server name.
+    ///
+    /// Refers to any credentials that are stored without using a server name using ``SecureStorage/store(credentials:server:removeDuplicate:storageScope:)``.
     public static let nonServerCredentials = SecureStorageItemTypes(rawValue: 1 << 2)
-    
-    /// Credentials as created with (``SecureStorage/store(credentials:server:removeDuplicate:storageScope:)``).
+
+    /// Any credentials created with the `SecureStorage` module.
+    ///
+    /// Refers to any credentials that are created using  ``SecureStorage/store(credentials:server:removeDuplicate:storageScope:)``.
     public static let credentials: SecureStorageItemTypes = [.serverCredentials, .nonServerCredentials]
     /// All types of items that can be handled by the secure storage component.
     public static let all: SecureStorageItemTypes = [.keys, .serverCredentials, .nonServerCredentials]

--- a/Sources/SpeziSecureStorage/SecureStorageScope.swift
+++ b/Sources/SpeziSecureStorage/SecureStorageScope.swift
@@ -9,7 +9,7 @@
 import Security
 
 
-/// The ``SecureStorageScope`` defines how secure data is stored by the ``SecureStorage`` component.
+/// Define how secure data is stored.
 public enum SecureStorageScope: Equatable, Identifiable {
     /// Store the element in the Secure Enclave
     case secureEnclave(userPresence: Bool = false)

--- a/Sources/SpeziSecureStorage/SpeziSecureStorage.docc/SpeziSecureStorage.md
+++ b/Sources/SpeziSecureStorage/SpeziSecureStorage.docc/SpeziSecureStorage.md
@@ -49,7 +49,7 @@ class ExampleDelegate: SpeziAppDelegate {
 }
 ```
 
-You can then use the ``SecureStorage`` class in any SwiftUI view.
+You can then use the `SecureStorage` class in any SwiftUI view.
 
 ```swift
 struct ExampleStorageView: View {
@@ -61,17 +61,17 @@ struct ExampleStorageView: View {
 }
 ```
 
-Alternatively, it is common to use the ``SecureStorage`` module in other modules as a dependency: [Spezi Module dependencies](https://swiftpackageindex.com/stanfordspezi/spezi/documentation/spezi/module-dependency).
+Alternatively, it is common to use the `SecureStorage` module in other modules as a dependency: [Spezi Module dependencies](https://swiftpackageindex.com/stanfordspezi/spezi/documentation/spezi/module-dependency).
 
 
 ## Use the SecureStorage Module
 
-You can use the ``SecureStorage`` module to store, update, retrieve, and delete credentials and keys. 
+You can use the `SecureStorage` module to store, update, retrieve, and delete credentials and keys. 
 
 
 ### Storing Credentials
 
-The ``SecureStorage`` module enables the storage of credentials in the Keychain.
+The `SecureStorage` module enables the storage of credentials in the Keychain.
 
 ```swift
 do {
@@ -98,7 +98,7 @@ See ``SecureStorage/store(credentials:server:removeDuplicate:storageScope:)`` fo
 
 ### Retrieving Credentials
 
-The ``SecureStorage`` module enables the retrieval of existing credentials stored in the Keychain.
+The `SecureStorage` module enables the retrieval of existing credentials stored in the Keychain.
 
 ```swift
 guard let serverCredentials = secureStorage.retrieveCredentials("user", server: "stanford.edu") else {
@@ -113,7 +113,7 @@ See ``SecureStorage/retrieveCredentials(_:server:accessGroup:)`` or ``SecureStor
 
 ### Updating Credentials
 
-The ``SecureStorage`` module enables the update of existing credentials found in the Keychain.
+The `SecureStorage` module enables the update of existing credentials found in the Keychain.
 
 ```swift
 do {
@@ -138,7 +138,7 @@ See ``SecureStorage/updateCredentials(_:server:newCredentials:newServer:removeDu
 
 ### Deleting Credentials
 
-The ``SecureStorage`` module enables the deletion of a previously stored set of credentials.
+The `SecureStorage` module enables the deletion of a previously stored set of credentials.
 
 ```swift
 do {
@@ -155,9 +155,9 @@ do {
 See ``SecureStorage/deleteCredentials(_:server:accessGroup:)`` or ``SecureStorage/deleteAllCredentials(itemTypes:accessGroup:)`` for more details.
 
 
-### Handeling Keys
+### Handling Keys
 
-Similiar to ``Credentials`` instances, you can also use the ``SecureStorage`` module to interact with keys.
+Similar to ``Credentials`` instances, you can also use the `SecureStorage` module to interact with keys.
 
 - ``SecureStorage/createKey(_:size:storageScope:)``
 - ``SecureStorage/retrievePublicKey(forTag:)``
@@ -171,21 +171,4 @@ Similiar to ``Credentials`` instances, you can also use the ``SecureStorage`` mo
 - ``SecureStorage``
 - ``SecureStorageError``
 - ``SecureStorageScope``
-
-### Handling Credentials 
-
-- ``Credentials``
-- ``SecureStorage/store(credentials:server:removeDuplicate:storageScope:)``
-- ``SecureStorage/retrieveCredentials(_:server:accessGroup:)``
-- ``SecureStorage/retrieveAllCredentials(forServer:accessGroup:)``
-- ``SecureStorage/updateCredentials(_:server:newCredentials:newServer:removeDuplicate:storageScope:)``
-- ``SecureStorage/deleteCredentials(_:server:accessGroup:)``
-- ``SecureStorage/deleteAllCredentials(itemTypes:accessGroup:)``
 - ``SecureStorageItemTypes``
-
-### Handling Keys 
-
-- ``SecureStorage/createKey(_:size:storageScope:)``
-- ``SecureStorage/retrievePublicKey(forTag:)``
-- ``SecureStorage/retrievePrivateKey(forTag:)``
-- ``SecureStorage/deleteKeys(forTag:)``


### PR DESCRIPTION
# Support CodableWithConfiguration when storing and retrieving from LocalStorage

## :recycle: Current situation & Problem
As of know, we only support storage and retrieval using `Encodable` and `Decodable` types. iOS 17 introduced a new set of protocols: `EncodableWithConfiguration` and `DecodableWithConfiguration`. Instead of relying on the `userInfo` dictionary and runtime checks to ensure configuration is supplied on the call site, type can now strictly define a certain configuration type that has to be supplied when encoding or decoding. There is also a new [`@CodableConfiguration`](https://developer.apple.com/documentation/foundation/codableconfiguration) property wrapper that can be used to statically define configurations for nested types.

To embrace these strongly typed configurations, SpeziStorage add support to accept types of these new protocols. We rely on the newly introduced `TopLevelEncoder` and `TopLevelDecoder` protocols introduced with https://github.com/StanfordSpezi/SpeziFoundation/pull/15 to stay generic over the encoder and decoder.

## :gear: Release Notes 
* Support storage and retrieval of `CodableWithConfiguration` types.
* Improved documentation.


## :books: Documentation
This PR reworks some of the documentation structure of SpeziStorage. Reducing some of the fluff and reorganizing the catalog a bit.

## :white_check_mark: Testing
--

## :pencil: Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
