### PR TITLE
Update swiftlint disable comments

### DIFF
--- a/Sources/SpeziLocalStorage/LocalStorage.swift
+++ b/Sources/SpeziLocalStorage/LocalStorage.swift
@@ -204,8 +204,8 @@ public final class LocalStorage: Module, DefaultInitializable, EnvironmentAccess
     ///   - storageKey: An optional storage key to identify the file.
     ///   - settings: The ``LocalStorageSetting``s used to retrieve the file on disk.
     /// - Returns: The element conforming to `Decodable`.
-    public func read<C: DecodableWithConfiguration, D: TopLevelDecoder>( // swiftlint:disable:this function_default_parameter_at_end
-        _ type: C.Type = C.self,
+    public func read<C: DecodableWithConfiguration, D: TopLevelDecoder>(
+        _ type: C.Type = C.self, // swiftlint:disable:this function_default_parameter_at_end
         configuration: C.DecodingConfiguration,
         decoder: D = JSONDecoder(),
         storageKey: String? = nil,

--- a/Sources/SpeziSecureStorage/SecureStorage.swift
+++ b/Sources/SpeziSecureStorage/SecureStorage.swift
@@ -306,10 +306,10 @@ public final class SecureStorage: Module, DefaultInitializable, EnvironmentAcces
     ///   - removeDuplicate: A flag indicating if any existing key for the `username` of the new credentials and `newServer`
     ///                      combination should be overwritten when storing the credentials.
     ///   - storageScope: The ``SecureStorageScope`` of the newly stored credentials.
-    public func updateCredentials( // swiftlint:disable:this function_default_parameter_at_end
+    public func updateCredentials(
         // The server parameter belongs to the `username` and therefore should be located next to the `username`.
         _ username: String,
-        server: String? = nil,
+        server: String? = nil, // swiftlint:disable:this function_default_parameter_at_end
         newCredentials: Credentials,
         newServer: String? = nil,
         removeDuplicate: Bool = true,


### PR DESCRIPTION
# Update swiftlint disable comments

## :recycle: Current situation & Problem
Latest swiftlint version updated where the warnings are surfaced. Therefore, we had to move the disable comments.


## :gear: Release Notes 
* Moved swiftlint disable comments.


## :pencil: Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
