### PR TITLE
add LocalStorageKey; rework LocalStorage API

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,10 +74,10 @@ Alternatively, it is common to use the `LocalStorage` or `SecureStorage` module 
 The `LocalStorage` module enables the on-disk storage of data in mobile applications.
 
 The `LocalStorage` module defaults to storing data encrypted supported by the `SecureStorage` module.
-The [`LocalStorageSetting`](https://swiftpackageindex.com/stanfordspezi/spezistorage/documentation/spezilocalstorage/localstoragesetting) enables configuring how data in the `LocalStorage` module can be stored and retrieved.
+The [`LocalStorageKey`](https://swiftpackageindex.com/stanfordspezi/spezistorage/documentation/spezilocalstorage/localstoragekey) type is used to define storage entries, and specify how data should be persisted.
 
-- Store or update new elements: [`store(_:encoder:storageKey:settings:)`](https://swiftpackageindex.com/stanfordspezi/spezistorage/documentation/spezilocalstorage/localstorage/store(_:encoder:storagekey:settings:))
-- Retrieve existing elements: [`read(_:decoder:storageKey:settings:)`](https://swiftpackageindex.com/stanfordspezi/spezistorage/documentation/spezilocalstorage/localstorage/read(_:decoder:storagekey:settings:))
+- Store or update new elements: [`store(_:for:)`](https://swiftpackageindex.com/stanfordspezi/spezistorage/documentation/spezilocalstorage/localstorage/store(_:for:))
+- Retrieve existing elements: [`load(_:)`](https://swiftpackageindex.com/stanfordspezi/spezistorage/documentation/spezilocalstorage/localstorage/load(_:))
 - Delete existing elements: [`delete(_:)`](https://swiftpackageindex.com/stanfordspezi/spezistorage/documentation/spezilocalstorage/localstorage/delete(_:))
 
 

--- a/Sources/SpeziLocalStorage/LocalStorage.swift
+++ b/Sources/SpeziLocalStorage/LocalStorage.swift
@@ -130,6 +130,7 @@ public final class LocalStorage: Module, DefaultInitializable, EnvironmentAccess
 
         try encryptedData.write(to: fileURL)
         try setResourceValues()
+        key.publisher.send(value)
     }
     
     
@@ -199,6 +200,7 @@ public final class LocalStorage: Module, DefaultInitializable, EnvironmentAccess
         if fileManager.fileExists(atPath: fileURL.path) {
             do {
                 try fileManager.removeItem(atPath: fileURL.path)
+                key.publisher.send(nil)
             } catch {
                 throw LocalStorageError.deletionNotPossible
             }

--- a/Sources/SpeziLocalStorage/LocalStorage.swift
+++ b/Sources/SpeziLocalStorage/LocalStorage.swift
@@ -130,7 +130,7 @@ public final class LocalStorage: Module, DefaultInitializable, EnvironmentAccess
 
         try encryptedData.write(to: fileURL)
         try setResourceValues()
-        key.publisher.send(value)
+        key.informSubscribersAboutNewValue(value)
     }
     
     
@@ -200,7 +200,7 @@ public final class LocalStorage: Module, DefaultInitializable, EnvironmentAccess
         if fileManager.fileExists(atPath: fileURL.path) {
             do {
                 try fileManager.removeItem(atPath: fileURL.path)
-                key.publisher.send(nil)
+                key.informSubscribersAboutNewValue(nil)
             } catch {
                 throw LocalStorageError.deletionNotPossible
             }

--- a/Sources/SpeziLocalStorage/LocalStorage.swift
+++ b/Sources/SpeziLocalStorage/LocalStorage.swift
@@ -256,7 +256,7 @@ public final class LocalStorage: Module, DefaultInitializable, EnvironmentAccess
     
     // MARK: File Handling
     
-    private func fileURL(for storageKey: LocalStorageKey<some Any>) -> URL {
+    func fileURL(for storageKey: LocalStorageKey<some Any>) -> URL {
         let storageKey = storageKey.key
         return localStorageDirectory.appending(path: storageKey).appendingPathExtension("localstorage")
     }

--- a/Sources/SpeziLocalStorage/LocalStorage.swift
+++ b/Sources/SpeziLocalStorage/LocalStorage.swift
@@ -24,23 +24,20 @@ import SpeziSecureStorage
 /// - ``init()``
 ///
 /// ### Storing Elements
-/// - ``store(_:encoder:storageKey:settings:)``
-/// - ``store(_:configuration:encoder:storageKey:settings:)``
+/// - ``store(_:for:)``
 ///
 /// ### Loading Elements
-/// - ``read(_:decoder:storageKey:settings:)``
-/// - ``read(_:configuration:decoder:storageKey:settings:)``
+/// - ``load(_:)``
 ///
 /// ### Deleting Entries
-///
 /// - ``delete(_:)``
-/// - ``delete(storageKey:)``
+/// - ``deleteAll()``
 public final class LocalStorage: Module, DefaultInitializable, EnvironmentAccessible, @unchecked Sendable {
     @Dependency(SecureStorage.self) private var secureStorage
     @Application(\.logger) private var logger
     
     private let fileManager = FileManager.default
-    private let localStorageDirectory: URL
+    /* private-but-tests */ let localStorageDirectory: URL
     private let encryptionAlgorithm: SecKeyAlgorithm = .eciesEncryptionCofactorX963SHA256AESGCM
     
     
@@ -53,6 +50,7 @@ public final class LocalStorage: Module, DefaultInitializable, EnvironmentAccess
     }
     
     
+    @_documentation(visibility: internal)
     public func configure() {
         do {
             try createLocalStorageDirectoryIfNecessary()
@@ -70,66 +68,28 @@ public final class LocalStorage: Module, DefaultInitializable, EnvironmentAccess
     }
     
     
-    /// Store elements on disk.
+    // MARK: Store
+    
+    /// Put a value into the `LocalStorage`.
     ///
-    /// ```swift
-    /// struct Note: Codable, Equatable {
-    ///     let text: String
-    ///     let date: Date
-    /// }
+    /// - parameter value: The value which should be persisted. Passing `nil` will delete the most-recently-stored value.
+    /// - parameter key: The ``LocalStorageKey`` with which the value should be associated.
     ///
-    /// let note = Note(text: "Spezi is awesome!", date: Date())
-    ///
-    /// do {
-    ///     try await localStorage.store(note)
-    /// } catch {
-    ///     // Handle storage errors ...
-    /// }
-    /// ```
-    ///
-    /// - Parameters:
-    ///   - element: The element that should be stored conforming to `Encodable`
-    ///   - encoder: The `Encoder` to use for encoding the `element`.
-    ///   - storageKey: An optional storage key to identify the file.
-    ///   - settings: The ``LocalStorageSetting``s applied to the file on disk.
-    public func store<C: Encodable, D: TopLevelEncoder>(
-        _ element: C,
-        encoder: D = JSONEncoder(),
-        storageKey: String? = nil,
-        settings: LocalStorageSetting = .encryptedUsingKeyChain()
-    ) throws where D.Output == Data {
-        try store(element, storageKey: storageKey, settings: settings) { element in
-            try encoder.encode(element)
+    /// - Note: This operation will overwrite any previously-stored values for this key.
+    public func store<Value>(_ value: Value?, for key: LocalStorageKey<Value>) throws {
+        try key.withWriteLock {
+            if let value {
+                try storeImp(value, for: key)
+            } else {
+                try delete(key)
+            }
         }
     }
-
-    /// Store elements on disk that require additional configuration for encoding.
-    ///
-    /// - Parameters:
-    ///   - element: The element that should be stored conforming to `Encodable`
-    ///   - configuration: A configuration that provides additional information for encoding.
-    ///   - encoder: The `Encoder` to use for encoding the `element`.
-    ///   - storageKey: An optional storage key to identify the file.
-    ///   - settings: The ``LocalStorageSetting``s applied to the file on disk.
-    public func store<C: EncodableWithConfiguration, D: TopLevelEncoder>(
-        _ element: C,
-        configuration: C.EncodingConfiguration,
-        encoder: D = JSONEncoder(),
-        storageKey: String? = nil,
-        settings: LocalStorageSetting = .encryptedUsingKeyChain()
-    ) throws where D.Output == Data {
-        try store(element, storageKey: storageKey, settings: settings) { element in
-            try encoder.encode(element, configuration: configuration)
-        }
-    }
-
-    private func store<C>(
-        _ element: C,
-        storageKey: String?,
-        settings: LocalStorageSetting,
-        encoding: (C) throws -> Data
-    ) throws {
-        var fileURL = fileURL(from: storageKey, type: C.self)
+    
+    
+    /// - invariant: assumes that the key's write lock is held.
+    private func storeImp<Value>(_ value: Value, for key: LocalStorageKey<Value>) throws {
+        var fileURL = fileURL(for: key)
         let fileExistsAlready = fileManager.fileExists(atPath: fileURL.path)
 
         // Called at the end of each execution path
@@ -137,7 +97,7 @@ public final class LocalStorage: Module, DefaultInitializable, EnvironmentAccess
         func setResourceValues() throws {
             do {
                 var resourceValues = URLResourceValues()
-                resourceValues.isExcludedFromBackup = settings.isExcludedFromBackup
+                resourceValues.isExcludedFromBackup = key.setting.isExcludedFromBackup
                 try fileURL.setResourceValues(resourceValues)
             } catch {
                 // Revert a written file if it did not exist before.
@@ -148,11 +108,10 @@ public final class LocalStorage: Module, DefaultInitializable, EnvironmentAccess
             }
         }
 
-        let data = try encoding(element)
-
+        let data = try key.encode(value)
 
         // Determine if the data should be encrypted or not:
-        guard let keys = try settings.keys(from: secureStorage) else {
+        guard let keys = try key.setting.keys(from: secureStorage) else {
             // No encryption:
             try data.write(to: fileURL)
             try setResourceValues()
@@ -172,68 +131,32 @@ public final class LocalStorage: Module, DefaultInitializable, EnvironmentAccess
         try encryptedData.write(to: fileURL)
         try setResourceValues()
     }
-
     
-    /// Read elements from disk.
+    
+    // MARK: Load
+    
+    /// Load a value from the `LocalStorage`.
     ///
-    /// ```swift
-    /// do {
-    ///     let storedNote: Note = try await localStorage.read()
-    ///     // Do something with `storedNote`.
-    /// } catch {
-    ///     // Handle read errors ...
-    /// }
-    /// ```
-    ///
-    /// - Parameters:
-    ///   - type: The `Decodable` type that is used to decode the data from disk.
-    ///   - decoder: The `Decoder` to use to decode the stored data into the provided `type`.
-    ///   - storageKey: An optional storage key to identify the file.
-    ///   - settings: The ``LocalStorageSetting``s used to retrieve the file on disk.
-    /// - Returns: The element conforming to `Decodable`.
-    public func read<C: Decodable, D: TopLevelDecoder>(
-        _ type: C.Type = C.self,
-        decoder: D = JSONDecoder(),
-        storageKey: String? = nil,
-        settings: LocalStorageSetting = .encryptedUsingKeyChain()
-    ) throws -> C where D.Input == Data {
-        try read(storageKey: storageKey, settings: settings) { data in
-            try decoder.decode(type, from: data)
+    /// - parameter key: The ``LocalStorageKey`` associated with the to-be-retrieved value.
+    /// - returns: The most recent stored value associated with the key; `nil` if no such value exists.
+    public func load<Value>(_ key: LocalStorageKey<Value>) throws -> Value? {
+        try key.withReadLock {
+            try readImp(key)
         }
     }
-
-    /// Read elements from disk that require additional configuration for decoding.
-    ///
-    /// - Parameters:
-    ///   - type: The `Decodable` type that is used to decode the data from disk.
-    ///   - configuration: A configuration that provides additional information for decoding.
-    ///   - decoder: The `Decoder` to use to decode the stored data into the provided `type`.
-    ///   - storageKey: An optional storage key to identify the file.
-    ///   - settings: The ``LocalStorageSetting``s used to retrieve the file on disk.
-    /// - Returns: The element conforming to `Decodable`.
-    public func read<C: DecodableWithConfiguration, D: TopLevelDecoder>(
-        _ type: C.Type = C.self, // swiftlint:disable:this function_default_parameter_at_end
-        configuration: C.DecodingConfiguration,
-        decoder: D = JSONDecoder(),
-        storageKey: String? = nil,
-        settings: LocalStorageSetting = .encryptedUsingKeyChain()
-    ) throws -> C where D.Input == Data {
-        try read(storageKey: storageKey, settings: settings) { data in
-            try decoder.decode(type, from: data, configuration: configuration)
+    
+    
+    /// - invariant: assumes that the key's read lock is held.
+    private func readImp<Value>(_ key: LocalStorageKey<Value>) throws -> Value? {
+        let fileURL = fileURL(for: key)
+        guard fileManager.fileExists(atPath: fileURL.path) else {
+            return nil
         }
-    }
-
-    private func read<C>(
-        storageKey: String?,
-        settings: LocalStorageSetting,
-        decoding: (Data) throws -> C
-    ) throws -> C {
-        let fileURL = fileURL(from: storageKey, type: C.self)
         let data = try Data(contentsOf: fileURL)
 
         // Determine if the data should be decrypted or not:
-        guard let keys = try settings.keys(from: secureStorage) else {
-            return try decoding(data)
+        guard let keys = try key.setting.keys(from: secureStorage) else {
+            return try key.decode(data)
         }
 
         guard SecKeyIsAlgorithmSupported(keys.privateKey, .decrypt, encryptionAlgorithm) else {
@@ -245,45 +168,34 @@ public final class LocalStorage: Module, DefaultInitializable, EnvironmentAccess
             throw LocalStorageError.decryptionNotPossible
         }
 
-        return try decoding(decryptedData)
+        return try key.decode(decryptedData)
     }
-
     
-    /// Deletes a file stored on disk identified by the `storageKey`.
+    
+    // MARK: Delete
+    
+    /// Deletes the `LocalStorage` entry associated with `key`.
     ///
     /// ```swift
     /// do {
-    ///     try await localStorage.delete(storageKey: "MyNote")
+    ///     try localStorage.delete(.myStorageKey)
     /// } catch {
     ///     // Handle delete errors ...
     /// }
     /// ```
     ///
-    /// Use ``delete(_:)`` as an automatically define the `storageKey` if the type conforms to `Encodable`.
-    ///
     /// - Parameters:
-    ///   - storageKey: An optional storage key to identify the file.
-    public func delete(storageKey: String) throws {
-        try delete(String.self, storageKey: storageKey)
-    }
-    
-    /// Deletes a file stored on disk defined by a  `Decodable` type that is used to derive the storage key.
-    ///
-    /// - Note: Use ``delete(storageKey:)`` to manually define the storage key.
-    ///
-    /// - Parameters:
-    ///   - type: The `Encodable` type that is used to store the type originally.
-    public func delete<C: Encodable>(_ type: C.Type = C.self) throws {
-        try delete(C.self, storageKey: nil)
+    ///   - key: An optional storage key to identify the file.
+    public func delete(_ key: LocalStorageKey<some Any>) throws {
+        try key.withWriteLock {
+            try deleteImp(key)
+        }
     }
     
     
-    private func delete<C: Encodable>(
-        _ type: C.Type = C.self,
-        storageKey: String? = nil
-    ) throws {
-        let fileURL = self.fileURL(from: storageKey, type: C.self)
-        
+    /// - invariant: assumes that the key's write lock is held
+    private func deleteImp(_ key: LocalStorageKey<some Any>) throws {
+        let fileURL = fileURL(for: key)
         if fileManager.fileExists(atPath: fileURL.path) {
             do {
                 try fileManager.removeItem(atPath: fileURL.path)
@@ -293,16 +205,47 @@ public final class LocalStorage: Module, DefaultInitializable, EnvironmentAccess
         }
     }
     
+    
     /// Deletes all data currently stored using the `LocalStorage` API.
     ///
     /// - Warning: This will delete all data currently stored using the `LocalStorage` API.
+    /// - Note: This operation is not synchronized with reads or writes on individual storage keys.
     public func deleteAll() throws {
         try fileManager.removeItem(at: localStorageDirectory)
         try createLocalStorageDirectoryIfNecessary()
     }
     
-    func fileURL<C>(from storageKey: String? = nil, type: C.Type = C.self) -> URL {
-        let storageKey = storageKey ?? String(describing: C.self)
+    
+    // MARK: Other
+    
+    
+    /// Modify a stored value in place
+    ///
+    /// Use this function to perform an atomic mutation of an entry in the `LocalStorage`.
+    ///
+    /// - parameter key: The ``LocalStorageKey`` whose value should be mutated.
+    /// - parameter transform: A mapping closure, which will be called with the current value stored for `key` (or `nil`, if no value is stored).
+    ///     The closure's return value will be stored into the `LocalStorage`, for the entry identified by `key`.
+    ///     If the closure returns `nil`, the entry will be removed from the `LocalStorage`.
+    ///
+    /// - throws: if `transform` throws,
+    public func modify<Value>(_ key: LocalStorageKey<Value>, transform: (Value?) throws -> Value?) throws {
+        try key.withWriteLock {
+            var value = try readImp(key)
+            value = try transform(value)
+            if let value {
+                try storeImp(value, for: key)
+            } else {
+                try deleteImp(key)
+            }
+        }
+    }
+    
+    
+    // MARK: File Handling
+    
+    func fileURL(for storageKey: LocalStorageKey<some Any>) -> URL {
+        let storageKey = storageKey.key
         return localStorageDirectory.appending(path: storageKey).appendingPathExtension("localstorage")
     }
 }

--- a/Sources/SpeziLocalStorage/LocalStorage.swift
+++ b/Sources/SpeziLocalStorage/LocalStorage.swift
@@ -81,7 +81,7 @@ public final class LocalStorage: Module, DefaultInitializable, EnvironmentAccess
             if let value {
                 try storeImp(value, for: key)
             } else {
-                try delete(key)
+                try deleteImp(key)
             }
         }
     }

--- a/Sources/SpeziLocalStorage/LocalStorage.swift
+++ b/Sources/SpeziLocalStorage/LocalStorage.swift
@@ -16,7 +16,9 @@ import SpeziSecureStorage
 /// Encrypted on-disk storage of data in mobile applications.
 ///
 /// The module relies on the [`SecureStorage`](https://swiftpackageindex.com/StanfordSpezi/SpeziStorage/documentation/spezisecurestorage)
-/// module to enable an encrypted on-disk storage. You can define the specifics of how data is stored using the ``LocalStorageSetting`` type.
+/// module to enable an encrypted on-disk storage.
+/// You interact with the ``LocalStorage`` API by defining custom ``LocalStorageKey``s, which are used to store values into the storage, and fetch them.
+/// The key also allows you to define how each individual entry should be stored: e.g., which encoding and encryption settings should be used.
 ///
 /// ## Topics
 ///
@@ -25,6 +27,7 @@ import SpeziSecureStorage
 ///
 /// ### Storing Elements
 /// - ``store(_:for:)``
+/// - ``modify(_:_:)``
 ///
 /// ### Loading Elements
 /// - ``load(_:)``
@@ -194,7 +197,7 @@ public final class LocalStorage: Module, DefaultInitializable, EnvironmentAccess
     /// ```
     ///
     /// - Parameters:
-    ///   - key: An optional storage key to identify the file.
+    ///   - key: The ``LocalStorageKey`` identifying the entry which should be deleted.
     public func delete(_ key: LocalStorageKey<some Any>) throws {
         try key.withWriteLock {
             try deleteImp(key)
@@ -228,7 +231,6 @@ public final class LocalStorage: Module, DefaultInitializable, EnvironmentAccess
     
     // MARK: Other
     
-    
     /// Modify a stored value in place
     ///
     /// Use this function to perform an atomic mutation of an entry in the `LocalStorage`.
@@ -239,7 +241,7 @@ public final class LocalStorage: Module, DefaultInitializable, EnvironmentAccess
     ///     If the closure sets `value` to `nil`, the entry will be removed from the `LocalStorage`.
     ///
     /// - throws: if `transform` throws,
-    public func modify<Value>(_ key: LocalStorageKey<Value>, transform: (_ value: inout Value?) throws -> Void) throws {
+    public func modify<Value>(_ key: LocalStorageKey<Value>, _ transform: (_ value: inout Value?) throws -> Void) throws {
         try key.withWriteLock {
             var value = try readImp(key)
             try transform(&value)
@@ -254,7 +256,7 @@ public final class LocalStorage: Module, DefaultInitializable, EnvironmentAccess
     
     // MARK: File Handling
     
-    func fileURL(for storageKey: LocalStorageKey<some Any>) -> URL {
+    private func fileURL(for storageKey: LocalStorageKey<some Any>) -> URL {
         let storageKey = storageKey.key
         return localStorageDirectory.appending(path: storageKey).appendingPathExtension("localstorage")
     }

--- a/Sources/SpeziLocalStorage/LocalStorageEntry.swift
+++ b/Sources/SpeziLocalStorage/LocalStorageEntry.swift
@@ -12,11 +12,16 @@ import SwiftUI
 
 /// Access ``LocalStorage`` entries within a SwiftUI View.
 @propertyWrapper
-public struct LocalStorageEntry<Value>: DynamicProperty {
+public struct LocalStorageEntry<Value>: DynamicProperty { // swiftlint:disable:this file_types_order
     private let key: LocalStorageKey<Value>
     
     @Environment(LocalStorage.self) private var localStorage
     @State private var internals = LocalStorageEntryInternals<Value>()
+    
+    public var wrappedValue: Value? {
+        get { internals.value }
+        set { try? localStorage.store(newValue, for: key) }
+    }
     
     public init(_ key: LocalStorageKey<Value>) {
         self.key = key
@@ -25,19 +30,14 @@ public struct LocalStorageEntry<Value>: DynamicProperty {
     public func update() {
         internals.subscribe(to: key, in: localStorage)
     }
-    
-    public var wrappedValue: Value? {
-        get { internals.value }
-        set { try? localStorage.store(newValue, for: key) }
-    }
 }
 
 
-@Observable private final class LocalStorageEntryInternals<Value> {
+@Observable
+private final class LocalStorageEntryInternals<Value> {
     fileprivate var value: Value?
     
-    @ObservationIgnored
-    private var cancellable: AnyCancellable?
+    @ObservationIgnored private var cancellable: AnyCancellable?
     
     func subscribe(to key: LocalStorageKey<Value>, in localStorage: LocalStorage) {
         cancellable?.cancel()

--- a/Sources/SpeziLocalStorage/LocalStorageEntry.swift
+++ b/Sources/SpeziLocalStorage/LocalStorageEntry.swift
@@ -20,7 +20,13 @@ public struct LocalStorageEntry<Value>: DynamicProperty { // swiftlint:disable:t
     
     public var wrappedValue: Value? {
         get { internals.value }
-        set { try? localStorage.store(newValue, for: key) }
+        nonmutating set {
+            if let newValue = newValue as? any Equatable, newValue.isEqual(internals.value as Any) {
+                // don't persist the same value again
+            } else {
+                try? localStorage.store(newValue, for: key)
+            }
+        }
     }
     
     public init(_ key: LocalStorageKey<Value>) {
@@ -45,5 +51,16 @@ private final class LocalStorageEntryInternals<Value> {
             self?.value = newValue
         }
         value = try? localStorage.load(key)
+    }
+}
+
+
+extension Equatable {
+    func isEqual(_ other: Any) -> Bool {
+        if let other = other as? Self {
+            self == other
+        } else {
+            false
+        }
     }
 }

--- a/Sources/SpeziLocalStorage/LocalStorageEntry.swift
+++ b/Sources/SpeziLocalStorage/LocalStorageEntry.swift
@@ -11,6 +11,33 @@ import SwiftUI
 
 
 /// Access ``LocalStorage`` entries within a SwiftUI View.
+///
+/// The property wrapper will automatically trigger a view update when the key's value in the ``LocalStorage`` changes.
+///
+/// Example:
+/// ```swift
+/// struct Person: Codable {
+///     let age: Int
+///     let name: String
+/// }
+///
+/// extension LocalStorageKeys {
+///     static let lastUser = LocalStorageKey<Person>("edu.stanford.spezi.app.lastUser")
+/// }
+///
+/// struct ExampleView: View {
+///     @LocalStorageEntry(.lastUser)
+///     private var lastUser
+///
+///     var body: some View {
+///         if let lastUser {
+///             UserDetailsView(lastUser)
+///         } else {
+///             ContentUnavailableView("No last user", image: "person.slash")
+///         }
+///     }
+/// }
+/// ```
 @propertyWrapper
 public struct LocalStorageEntry<Value>: DynamicProperty { // swiftlint:disable:this file_types_order
     private let key: LocalStorageKey<Value>
@@ -29,10 +56,12 @@ public struct LocalStorageEntry<Value>: DynamicProperty { // swiftlint:disable:t
         }
     }
     
+    /// Creates a new `LocalStorageEntry` for the specified storage key
     public init(_ key: LocalStorageKey<Value>) {
         self.key = key
     }
     
+    @_documentation(visibility: internal)
     public func update() {
         internals.subscribe(to: key, in: localStorage)
     }

--- a/Sources/SpeziLocalStorage/LocalStorageEntry.swift
+++ b/Sources/SpeziLocalStorage/LocalStorageEntry.swift
@@ -1,0 +1,49 @@
+//
+// This source file is part of the Stanford Spezi open-source project
+//
+// SPDX-FileCopyrightText: 2025 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+import Combine
+import SwiftUI
+
+
+/// Access ``LocalStorage`` entries within a SwiftUI View.
+@propertyWrapper
+public struct LocalStorageEntry<Value>: DynamicProperty {
+    private let key: LocalStorageKey<Value>
+    
+    @Environment(LocalStorage.self) private var localStorage
+    @State private var internals = LocalStorageEntryInternals<Value>()
+    
+    public init(_ key: LocalStorageKey<Value>) {
+        self.key = key
+    }
+    
+    public func update() {
+        internals.subscribe(to: key, in: localStorage)
+    }
+    
+    public var wrappedValue: Value? {
+        get { internals.value }
+        set { try? localStorage.store(newValue, for: key) }
+    }
+}
+
+
+@Observable private final class LocalStorageEntryInternals<Value> {
+    fileprivate var value: Value?
+    
+    @ObservationIgnored
+    private var cancellable: AnyCancellable?
+    
+    func subscribe(to key: LocalStorageKey<Value>, in localStorage: LocalStorage) {
+        cancellable?.cancel()
+        cancellable = key.publisher.sink { [weak self] newValue in
+            self?.value = newValue
+        }
+        value = try? localStorage.load(key)
+    }
+}

--- a/Sources/SpeziLocalStorage/LocalStorageKey.swift
+++ b/Sources/SpeziLocalStorage/LocalStorageKey.swift
@@ -1,0 +1,138 @@
+//
+// This source file is part of the Stanford Spezi open-source project
+//
+// SPDX-FileCopyrightText: 2025 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+import Dispatch
+import Foundation
+import SpeziFoundation
+
+
+/// Used to statically define ``LocalStorageKey``s.
+///
+/// - Important: Your code does not use this type directly, apart from extending it when defining storage keys.
+public class LocalStorageKeys {
+    fileprivate init() {}
+}
+
+
+/// Type-safe key for ``LocalStorage``.
+///
+/// `LocalStorageKey` objects are used to define how data is stored to and loaded from the ``LocalStorage`` module.
+///
+/// The `LocalStorageKey` defines how and where data associated with the key is stored, encoded, and decoded.
+/// It furthermore acts as a lock when accessing data from a ``LocalStorage``.
+///
+/// - Important: All `LocalStorageKey`s used in an application must have unique, stable underlying `key`s.
+/// Defining and using two or more `LocalStorageKey`s with identical underlying `key`s will lead to conflicts and data loss or corruption.
+/// It is advised that you use a reverse-DNS-style naming scheme for your keys, in order to avoid name collisions.
+///
+/// ### Supported Types
+/// - `Codable` types
+/// - `NSSecureCoding`-compliant types
+/// - Raw `Data` objects
+/// - Any other type (requires providing custom encoding and decoding handlers)
+///
+/// ### Example
+/// ```swift
+/// struct Note: Codable {
+///     let date: Date
+///     let text: String
+/// }
+///
+/// struct Person: Codable {
+///     let name: String
+///     let dateOfBirth: DateComponents
+/// }
+///
+/// extension LocalStorageKeys {
+///     static let note = LocalStorageKey<Note>("note")
+///     static let person = LocalStorageKey<Person>("person", encoder: PropertyListEncoder(), decoder: PropertyListDecoder())
+/// }
+/// ```
+///
+/// ## Topics
+/// ### Creating Storage Keys
+/// - ``init(_:setting:)-21oqu``
+/// - ``init(_:setting:encoder:decoder:)``
+/// - ``init(_:setting:)-1sf9p``
+/// - ``init(_:setting:)-9t3s8``
+/// - ``init(key:setting:encode:decode:)``
+///
+/// ### Other
+/// - ``LocalStorageKeys``
+public final class LocalStorageKey<Value>: LocalStorageKeys, @unchecked Sendable {
+    let key: String
+    let setting: LocalStorageSetting
+    let encode: @Sendable (Value) throws -> Data
+    let decode: @Sendable (Data) throws -> Value?
+    private let lock = RWLock()
+    
+    /// Creates a Local Storage Key that uses custom encoding and decoding functions.
+    public init(
+        key: String,
+        setting: LocalStorageSetting = .default,
+        encode: @Sendable @escaping (Value) throws -> Data,
+        decode: @Sendable @escaping (Data) throws -> Value?
+    ) {
+        self.key = key
+        self.setting = setting
+        self.encode = encode
+        self.decode = decode
+    }
+    
+    func withReadLock<Result>(_ block: () throws -> Result) rethrows -> Result {
+        try lock.withReadLock(body: block)
+    }
+    
+    func withWriteLock<Result>(_ block: () throws -> Result) rethrows -> Result {
+        try lock.withWriteLock(body: block)
+    }
+}
+
+
+extension LocalStorageKey {
+    /// Creates a Local Storage Key that uses JSON to encode and decode its entries.
+    public convenience init(_ key: String, setting: LocalStorageSetting = .default) where Value: Codable {
+        self.init(key, setting: setting, encoder: JSONEncoder(), decoder: JSONDecoder())
+    }
+    
+    /// Creates a Local Storage Key that uses a custom encoder and decoder.
+    public convenience init<E: TopLevelEncoder & Sendable, D: TopLevelDecoder & Sendable>(
+        _ key: String,
+        setting: LocalStorageSetting = .default,
+        encoder: E,
+        decoder: D
+    ) where Value: Codable, E.Output == Data, D.Input == Data {
+        self.init(key: key, setting: setting) { value in
+            try encoder.encode(value)
+        } decode: { data in
+            try decoder.decode(Value.self, from: data)
+        }
+    }
+    
+    /// Creates a Local Storage Key for storing and loading `NSSecureCoding`-compliant objects.
+    public convenience init(_ key: String, setting: LocalStorageSetting = .default) where Value: NSObject & NSSecureCoding {
+        self.init(key: key, setting: setting) { value in
+            try NSKeyedArchiver.archivedData(withRootObject: value, requiringSecureCoding: true)
+        } decode: { data in
+            try NSKeyedUnarchiver.unarchivedObject(ofClass: Value.self, from: data)
+        }
+    }
+    
+    /// Creates a Local Storage Key for storing and loading `Data` objects.
+    ///
+    /// This initializer allows more efficient persistance: if the value is already `Data`, there is no need to perform a dedicated encoding or decoding step.
+    public convenience init(_ key: String, setting: LocalStorageSetting = .default) where Value == Data {
+        self.init(key: key, setting: setting, encode: { $0 }, decode: { $0 })
+    }
+}
+
+
+extension LocalStorageSetting {
+    /// The default storage setting.
+    public static var `default`: Self { .encryptedUsingKeyChain() }
+}

--- a/Sources/SpeziLocalStorage/LocalStorageKey.swift
+++ b/Sources/SpeziLocalStorage/LocalStorageKey.swift
@@ -72,7 +72,7 @@ public final class LocalStorageKey<Value>: LocalStorageKeys, @unchecked Sendable
     private let lock = RWLock()
     private let subject = PassthroughSubject<Value?, Never>()
     
-    var publisher: AnyPublisher<Value?, Never> { subject.eraseToAnyPublisher() }
+    var publisher: some Publisher<Value?, Never> { subject }
     
     /// Creates a Local Storage Key that uses custom encoding and decoding functions.
     public init(

--- a/Sources/SpeziLocalStorage/LocalStorageKey.swift
+++ b/Sources/SpeziLocalStorage/LocalStorageKey.swift
@@ -70,7 +70,9 @@ public final class LocalStorageKey<Value>: LocalStorageKeys, @unchecked Sendable
     let encode: @Sendable (Value) throws -> Data
     let decode: @Sendable (Data) throws -> Value?
     private let lock = RWLock()
-    let publisher = PassthroughSubject<Value?, Never>()
+    private let subject = PassthroughSubject<Value?, Never>()
+    
+    var publisher: AnyPublisher<Value?, Never> { subject.eraseToAnyPublisher() }
     
     /// Creates a Local Storage Key that uses custom encoding and decoding functions.
     public init(
@@ -91,6 +93,10 @@ public final class LocalStorageKey<Value>: LocalStorageKeys, @unchecked Sendable
     
     func withWriteLock<Result>(_ block: () throws -> Result) rethrows -> Result {
         try lock.withWriteLock(body: block)
+    }
+    
+    func informSubscribersAboutNewValue(_ newValue: Value?) {
+        subject.send(newValue)
     }
 }
 

--- a/Sources/SpeziLocalStorage/LocalStorageKey.swift
+++ b/Sources/SpeziLocalStorage/LocalStorageKey.swift
@@ -49,8 +49,8 @@ public class LocalStorageKeys {
 /// }
 ///
 /// extension LocalStorageKeys {
-///     static let note = LocalStorageKey<Note>("note")
-///     static let person = LocalStorageKey<Person>("person", encoder: PropertyListEncoder(), decoder: PropertyListDecoder())
+///     static let note = LocalStorageKey<Note>("edu.stanford.spezi.exampleNote")
+///     static let person = LocalStorageKey<Person>("edu.stanford.spezi.examplePerson", encoder: PropertyListEncoder(), decoder: PropertyListDecoder())
 /// }
 /// ```
 ///

--- a/Sources/SpeziLocalStorage/LocalStorageKey.swift
+++ b/Sources/SpeziLocalStorage/LocalStorageKey.swift
@@ -103,7 +103,7 @@ extension LocalStorageKey {
     /// Creates a Local Storage Key that uses a custom encoder and decoder.
     public convenience init<E: TopLevelEncoder & Sendable, D: TopLevelDecoder & Sendable>(
         _ key: String,
-        setting: LocalStorageSetting = .default,
+        setting: LocalStorageSetting = .default, // swiftlint:disable:this function_default_parameter_at_end
         encoder: E,
         decoder: D
     ) where Value: Codable, E.Output == Data, D.Input == Data {

--- a/Sources/SpeziLocalStorage/LocalStorageKey.swift
+++ b/Sources/SpeziLocalStorage/LocalStorageKey.swift
@@ -6,7 +6,7 @@
 // SPDX-License-Identifier: MIT
 //
 
-import Dispatch
+import Combine
 import Foundation
 import SpeziFoundation
 
@@ -70,6 +70,7 @@ public final class LocalStorageKey<Value>: LocalStorageKeys, @unchecked Sendable
     let encode: @Sendable (Value) throws -> Data
     let decode: @Sendable (Data) throws -> Value?
     private let lock = RWLock()
+    let publisher = PassthroughSubject<Value?, Never>()
     
     /// Creates a Local Storage Key that uses custom encoding and decoding functions.
     public init(
@@ -101,7 +102,7 @@ extension LocalStorageKey {
     }
     
     /// Creates a Local Storage Key that uses a custom encoder and decoder.
-    public convenience init<E: TopLevelEncoder & Sendable, D: TopLevelDecoder & Sendable>(
+    public convenience init<E: SpeziFoundation.TopLevelEncoder & Sendable, D: SpeziFoundation.TopLevelDecoder & Sendable>(
         _ key: String,
         setting: LocalStorageSetting = .default, // swiftlint:disable:this function_default_parameter_at_end
         encoder: E,

--- a/Sources/SpeziLocalStorage/LocalStorageSetting.swift
+++ b/Sources/SpeziLocalStorage/LocalStorageSetting.swift
@@ -14,21 +14,21 @@ import SpeziSecureStorage
 /// Configure how data is encrypyed, stored, and retrieved.
 public enum LocalStorageSetting {
     /// Unencrypted
-    case unencrypted(excludedFromBackup: Bool = true)
+    case unencrypted(excludeFromBackup: Bool = true)
     /// Encrypted using a `eciesEncryptionCofactorX963SHA256AESGCM` key: private key for encryption and a public key for decryption.
-    case encrypted(privateKey: SecKey, publicKey: SecKey, excludedFromBackup: Bool = true)
+    case encrypted(privateKey: SecKey, publicKey: SecKey, excludeFromBackup: Bool = true)
     /// Encrypted using a `eciesEncryptionCofactorX963SHA256AESGCM` key stored in the Secure Enclave.
     case encryptedUsingSecureEnclave(userPresence: Bool = false)
     /// Encrypted using a `eciesEncryptionCofactorX963SHA256AESGCM` key stored in the Keychain.
-    case encryptedUsingKeyChain(userPresence: Bool = false, excludedFromBackup: Bool = true)
+    case encryptedUsingKeyChain(userPresence: Bool = false, excludeFromBackup: Bool = true)
     
     
     var isExcludedFromBackup: Bool {
         switch self {
-        case let .unencrypted(excludedFromBackup),
-             let .encrypted(_, _, excludedFromBackup),
-             let .encryptedUsingKeyChain(_, excludedFromBackup):
-            return excludedFromBackup
+        case let .unencrypted(excludeFromBackup),
+             let .encrypted(_, _, excludeFromBackup),
+             let .encryptedUsingKeyChain(_, excludeFromBackup):
+            return excludeFromBackup
         case .encryptedUsingSecureEnclave:
             return true
         }

--- a/Sources/SpeziLocalStorage/SpeziLocalStorage.docc/SpeziLocalStorage.md
+++ b/Sources/SpeziLocalStorage/SpeziLocalStorage.docc/SpeziLocalStorage.md
@@ -64,10 +64,23 @@ Alternatively, it is common to use the `LocalStorage` module in other modules as
 
 ## Use the LocalStorage Module
 
-You can use the `LocalStorage` module to store, update, retrieve, and delete element conforming to [`Codable`](https://developer.apple.com/documentation/swift/codable). 
+You can use the `LocalStorage` module to store, update, retrieve, and delete element conforming to [`Codable`](https://developer.apple.com/documentation/swift/codable).
 
 
-### Storing & Update Data
+### Defining Storage Keys
+
+`LocalStorage` uses unique ``LocalStorageKey``s to .
+
+You define storage keys by placing a static non-computed properties of type ``LocalStorageKey`` into an extension on the ``LocalStorageKeys`` type:
+
+```swift
+extension LocalStorageKeys {
+    static let note = LocalStorageKey
+}
+```
+
+
+### Storing and Loading Data
 
 The `LocalStorage` module enables the storage and update of elements conforming to `Codable`.
 

--- a/Tests/SpeziLocalStorageTests/LocalStorageTests.swift
+++ b/Tests/SpeziLocalStorageTests/LocalStorageTests.swift
@@ -160,13 +160,13 @@ final class LocalStorageTests: XCTestCase {
         let key = LocalStorageKey<String>("abcabc", setting: .unencrypted())
         XCTAssertFalse(localStorage.hasEntry(for: key))
         try localStorage.modify(key) { value in
-            XCTAssertTrue(value == nil)
+            XCTAssertNil(value)
             value = "heyyy"
         }
         XCTAssertTrue(localStorage.hasEntry(for: key))
         XCTAssertEqual(try localStorage.load(key), "heyyy")
         try localStorage.modify(key) { value in
-            XCTAssertFalse(value == nil)
+            XCTAssertNotNil(value)
             XCTAssertEqual(value, "heyyy")
             value = nil
         }

--- a/Tests/SpeziLocalStorageTests/LocalStorageTests.swift
+++ b/Tests/SpeziLocalStorageTests/LocalStorageTests.swift
@@ -16,8 +16,8 @@ private struct Letter: Codable, Equatable {
 }
 
 
-private extension LocalStorageKeys {
-    static let letter = LocalStorageKey<Letter>("letter", setting: .unencrypted())
+extension LocalStorageKeys { // swiftlint:disable:this file_types_order
+    fileprivate static let letter = LocalStorageKey<Letter>("letter", setting: .unencrypted())
 }
 
 
@@ -92,21 +92,36 @@ final class LocalStorageTests: XCTestCase {
         let letter = Letter(greeting: "Hello Lukas 😳😳😳")
         
         try localStorage.store(letter, for: keyNoBackup)
-        try assertItemAtUrlIsExcludedFromBackupEquals(localStorage.fileURL(for: keyNoBackup), shouldBeExcluded: keyNoBackup.setting.isExcludedFromBackup)
+        try assertItemAtUrlIsExcludedFromBackupEquals(
+            localStorage.fileURL(for: keyNoBackup),
+            shouldBeExcluded: keyNoBackup.setting.isExcludedFromBackup
+        )
         
         try localStorage.store(letter, for: keyYesBackup)
-        try assertItemAtUrlIsExcludedFromBackupEquals(localStorage.fileURL(for: keyYesBackup), shouldBeExcluded: keyYesBackup.setting.isExcludedFromBackup)
+        try assertItemAtUrlIsExcludedFromBackupEquals(
+            localStorage.fileURL(for: keyYesBackup),
+            shouldBeExcluded: keyYesBackup.setting.isExcludedFromBackup
+        )
         
         try localStorage.deleteAll()
         
         try localStorage.store(letter, for: keyYesBackup)
-        try assertItemAtUrlIsExcludedFromBackupEquals(localStorage.fileURL(for: keyYesBackup), shouldBeExcluded: keyYesBackup.setting.isExcludedFromBackup)
+        try assertItemAtUrlIsExcludedFromBackupEquals(
+            localStorage.fileURL(for: keyYesBackup),
+            shouldBeExcluded: keyYesBackup.setting.isExcludedFromBackup
+        )
         
         try localStorage.store(letter, for: keyNoBackup)
-        try assertItemAtUrlIsExcludedFromBackupEquals(localStorage.fileURL(for: keyNoBackup), shouldBeExcluded: keyNoBackup.setting.isExcludedFromBackup)
+        try assertItemAtUrlIsExcludedFromBackupEquals(
+            localStorage.fileURL(for: keyNoBackup),
+            shouldBeExcluded: keyNoBackup.setting.isExcludedFromBackup
+        )
         
         try localStorage.store(letter, for: keyYesBackup)
-        try assertItemAtUrlIsExcludedFromBackupEquals(localStorage.fileURL(for: keyYesBackup), shouldBeExcluded: keyYesBackup.setting.isExcludedFromBackup)
+        try assertItemAtUrlIsExcludedFromBackupEquals(
+            localStorage.fileURL(for: keyYesBackup),
+            shouldBeExcluded: keyYesBackup.setting.isExcludedFromBackup
+        )
     }
     
     

--- a/Tests/SpeziLocalStorageTests/LocalStorageTests.swift
+++ b/Tests/SpeziLocalStorageTests/LocalStorageTests.swift
@@ -148,4 +148,28 @@ final class LocalStorageTests: XCTestCase {
         try localStorage.deleteAll()
         XCTAssertTrue(try fileManager.contentsOfDirectory(atPath: localStorageDir.path).isEmpty)
     }
+    
+    
+    @MainActor
+    func testModify() throws {
+        let localStorage = LocalStorage()
+        withDependencyResolution {
+            localStorage
+        }
+        
+        let key = LocalStorageKey<String>("abcabc", setting: .unencrypted())
+        XCTAssertFalse(localStorage.hasEntry(for: key))
+        try localStorage.modify(key) { value in
+            XCTAssertTrue(value == nil)
+            value = "heyyy"
+        }
+        XCTAssertTrue(localStorage.hasEntry(for: key))
+        XCTAssertEqual(try localStorage.load(key), "heyyy")
+        try localStorage.modify(key) { value in
+            XCTAssertFalse(value == nil)
+            XCTAssertEqual(value, "heyyy")
+            value = nil
+        }
+        XCTAssertFalse(localStorage.hasEntry(for: key))
+    }
 }

--- a/Tests/SpeziLocalStorageTests/LocalStorageTests.swift
+++ b/Tests/SpeziLocalStorageTests/LocalStorageTests.swift
@@ -58,12 +58,18 @@ final class LocalStorageTests: XCTestCase {
         }
         
         let letter = Letter(greeting: "Hello Paul 👋\(String(repeating: "🚀", count: Int.random(in: 0...10)))")
+        
+        // 1: test "normal" deletion
         try localStorage.store(letter, for: .letter)
-        let storedLetter = try localStorage.load(.letter)
-        
-        XCTAssertEqual(letter, storedLetter)
-        
+        XCTAssertEqual(letter, try localStorage.load(.letter))
         try localStorage.delete(.letter)
+        XCTAssertNil(try localStorage.load(.letter))
+        XCTAssertNoThrow(try localStorage.delete(.letter))
+        
+        // 2: test deletion by storing nil
+        try localStorage.store(letter, for: .letter)
+        XCTAssertEqual(letter, try localStorage.load(.letter))
+        try localStorage.store(nil, for: .letter)
         XCTAssertNil(try localStorage.load(.letter))
         XCTAssertNoThrow(try localStorage.delete(.letter))
     }

--- a/Tests/SpeziLocalStorageTests/LocalStorageTests.swift
+++ b/Tests/SpeziLocalStorageTests/LocalStorageTests.swift
@@ -64,7 +64,7 @@ final class LocalStorageTests: XCTestCase {
         XCTAssertEqual(letter, storedLetter)
         
         try localStorage.delete(.letter)
-        XCTAssertThrowsError(try localStorage.load(.letter))
+        XCTAssertNil(try localStorage.load(.letter))
         XCTAssertNoThrow(try localStorage.delete(.letter))
     }
     
@@ -143,7 +143,7 @@ final class LocalStorageTests: XCTestCase {
         
         XCTAssertTrue(try fileManager.contentsOfDirectory(atPath: localStorageDir.path).isEmpty)
         
-        try localStorage.store("Servus", for: .init("hmmmm"))
+        try localStorage.store("Servus", for: .init("hmmmm", setting: .unencrypted()))
         XCTAssertFalse(try fileManager.contentsOfDirectory(atPath: localStorageDir.path).isEmpty)
         try localStorage.deleteAll()
         XCTAssertTrue(try fileManager.contentsOfDirectory(atPath: localStorageDir.path).isEmpty)

--- a/Tests/SpeziLocalStorageTests/LocalStorageTests.swift
+++ b/Tests/SpeziLocalStorageTests/LocalStorageTests.swift
@@ -178,4 +178,19 @@ final class LocalStorageTests: XCTestCase {
         }
         XCTAssertFalse(localStorage.hasEntry(for: key))
     }
+    
+    
+    @MainActor
+    func testStoreData() throws {
+        let localStorage = LocalStorage()
+        withDependencyResolution {
+            localStorage
+        }
+        
+        let key = LocalStorageKey<Data>("ayoooo", setting: .unencrypted())
+        let data = Data([83, 112, 101, 122, 105, 32, 105, 115, 32, 99, 111, 111, 108])
+        try localStorage.store(data, for: key)
+        XCTAssertEqual(try Data(contentsOf: localStorage.fileURL(for: key)), data)
+        XCTAssertEqual(try localStorage.load(key), data)
+    }
 }

--- a/Tests/SpeziLocalStorageTests/LocalStorageTests.swift
+++ b/Tests/SpeziLocalStorageTests/LocalStorageTests.swift
@@ -11,12 +11,17 @@ import XCTest
 import XCTSpezi
 
 
+private struct Letter: Codable, Equatable {
+    let greeting: String
+}
+
+
+private extension LocalStorageKeys {
+    static let letter = LocalStorageKey<Letter>("letter", setting: .unencrypted())
+}
+
+
 final class LocalStorageTests: XCTestCase {
-    private struct Letter: Codable, Equatable {
-        let greeting: String
-    }
-    
-    
     override func setUp() async throws {
         try await super.setUp()
         // Before each test, we want to fully reset the LocalStorage
@@ -38,13 +43,10 @@ final class LocalStorageTests: XCTestCase {
         }
         
         let letter = Letter(greeting: "Hello Paul 👋\(String(repeating: "🚀", count: Int.random(in: 0...10)))")
-        try localStorage.store(letter, settings: .unencrypted())
-        let storedLetter: Letter = try localStorage.read(settings: .unencrypted())
+        try localStorage.store(letter, for: .letter)
+        let storedLetter = try localStorage.load(.letter)
         
         XCTAssertEqual(letter, storedLetter)
-        
-        try localStorage.delete(Letter.self)
-        try localStorage.delete(storageKey: "Letter")
     }
     
     
@@ -56,14 +58,14 @@ final class LocalStorageTests: XCTestCase {
         }
         
         let letter = Letter(greeting: "Hello Paul 👋\(String(repeating: "🚀", count: Int.random(in: 0...10)))")
-        try localStorage.store(letter, settings: .unencrypted())
-        let storedLetter: Letter = try localStorage.read(settings: .unencrypted())
+        try localStorage.store(letter, for: .letter)
+        let storedLetter = try localStorage.load(.letter)
         
         XCTAssertEqual(letter, storedLetter)
         
-        try localStorage.delete(Letter.self)
-        XCTAssertThrowsError(try localStorage.read(Letter.self, settings: .unencrypted()))
-        XCTAssertNoThrow(try localStorage.delete(Letter.self))
+        try localStorage.delete(.letter)
+        XCTAssertThrowsError(try localStorage.load(.letter))
+        XCTAssertNoThrow(try localStorage.delete(.letter))
     }
     
     
@@ -79,6 +81,9 @@ final class LocalStorageTests: XCTestCase {
             XCTAssertEqual(isExcluded, shouldBeExcluded, file: file, line: line)
         }
         
+        let keyYesBackup = LocalStorageKey<Letter>("letter1", setting: .unencrypted(excludeFromBackup: false))
+        let keyNoBackup = LocalStorageKey<Letter>("letter2", setting: .unencrypted(excludeFromBackup: true))
+        
         let localStorage = LocalStorage()
         withDependencyResolution {
             localStorage
@@ -86,22 +91,22 @@ final class LocalStorageTests: XCTestCase {
         
         let letter = Letter(greeting: "Hello Lukas 😳😳😳")
         
-        try localStorage.store(letter, storageKey: "letter", settings: .unencrypted(excludedFromBackup: true))
-        try assertItemAtUrlIsExcludedFromBackupEquals(localStorage.fileURL(from: "letter", type: Letter.self), shouldBeExcluded: true)
+        try localStorage.store(letter, for: keyNoBackup)
+        try assertItemAtUrlIsExcludedFromBackupEquals(localStorage.fileURL(for: keyNoBackup), shouldBeExcluded: keyNoBackup.setting.isExcludedFromBackup)
         
-        try localStorage.store(letter, storageKey: "letter", settings: .unencrypted(excludedFromBackup: false))
-        try assertItemAtUrlIsExcludedFromBackupEquals(localStorage.fileURL(from: "letter", type: Letter.self), shouldBeExcluded: false)
+        try localStorage.store(letter, for: keyYesBackup)
+        try assertItemAtUrlIsExcludedFromBackupEquals(localStorage.fileURL(for: keyYesBackup), shouldBeExcluded: keyYesBackup.setting.isExcludedFromBackup)
         
-        try localStorage.delete(storageKey: "letter")
+        try localStorage.deleteAll()
         
-        try localStorage.store(letter, storageKey: "letter", settings: .unencrypted(excludedFromBackup: false))
-        try assertItemAtUrlIsExcludedFromBackupEquals(localStorage.fileURL(from: "letter", type: Letter.self), shouldBeExcluded: false)
+        try localStorage.store(letter, for: keyYesBackup)
+        try assertItemAtUrlIsExcludedFromBackupEquals(localStorage.fileURL(for: keyYesBackup), shouldBeExcluded: keyYesBackup.setting.isExcludedFromBackup)
         
-        try localStorage.store(letter, storageKey: "letter", settings: .unencrypted(excludedFromBackup: true))
-        try assertItemAtUrlIsExcludedFromBackupEquals(localStorage.fileURL(from: "letter", type: Letter.self), shouldBeExcluded: true)
+        try localStorage.store(letter, for: keyNoBackup)
+        try assertItemAtUrlIsExcludedFromBackupEquals(localStorage.fileURL(for: keyNoBackup), shouldBeExcluded: keyNoBackup.setting.isExcludedFromBackup)
         
-        try localStorage.store(letter, storageKey: "letter", settings: .unencrypted(excludedFromBackup: false))
-        try assertItemAtUrlIsExcludedFromBackupEquals(localStorage.fileURL(from: "letter", type: Letter.self), shouldBeExcluded: false)
+        try localStorage.store(letter, for: keyYesBackup)
+        try assertItemAtUrlIsExcludedFromBackupEquals(localStorage.fileURL(for: keyYesBackup), shouldBeExcluded: keyYesBackup.setting.isExcludedFromBackup)
     }
     
     
@@ -113,7 +118,7 @@ final class LocalStorageTests: XCTestCase {
             localStorage
         }
         
-        let localStorageDir = localStorage.fileURL(from: "abc", type: Void.self).deletingLastPathComponent()
+        let localStorageDir = localStorage.localStorageDirectory
         do {
             var isDirectory: ObjCBool = false
             let exists = fileManager.fileExists(atPath: localStorageDir.path, isDirectory: &isDirectory)
@@ -123,7 +128,7 @@ final class LocalStorageTests: XCTestCase {
         
         XCTAssertTrue(try fileManager.contentsOfDirectory(atPath: localStorageDir.path).isEmpty)
         
-        try localStorage.store("Servus", storageKey: "myText", settings: .unencrypted())
+        try localStorage.store("Servus", for: .init("hmmmm"))
         XCTAssertFalse(try fileManager.contentsOfDirectory(atPath: localStorageDir.path).isEmpty)
         try localStorage.deleteAll()
         XCTAssertTrue(try fileManager.contentsOfDirectory(atPath: localStorageDir.path).isEmpty)

--- a/Tests/SpeziLocalStorageTests/LocalStorageTests.swift
+++ b/Tests/SpeziLocalStorageTests/LocalStorageTests.swift
@@ -187,10 +187,26 @@ final class LocalStorageTests: XCTestCase {
             localStorage
         }
         
+        // Test that raw data is not run through an extra encoding/decoding step, and instead simply encoded/decoded as-is.
         let key = LocalStorageKey<Data>("ayoooo", setting: .unencrypted())
         let data = Data([83, 112, 101, 122, 105, 32, 105, 115, 32, 99, 111, 111, 108])
         try localStorage.store(data, for: key)
         XCTAssertEqual(try Data(contentsOf: localStorage.fileURL(for: key)), data)
         XCTAssertEqual(try localStorage.load(key), data)
+    }
+    
+    
+    @MainActor
+    func testNSSecureCoding() throws {
+        let localStorage = LocalStorage()
+        withDependencyResolution {
+            localStorage
+        }
+        
+        let key = LocalStorageKey<NSArray>("testTest123", setting: .unencrypted())
+        let array = NSArray(array: ["hello", "spezi"])
+        try localStorage.store(array, for: key)
+        XCTAssertTrue(array.isEqual(try localStorage.load(key)))
+        XCTAssertFalse(array is Codable) // make sure we're actually using the NSSecureCoding path here...
     }
 }

--- a/Tests/UITests/TestApp/LocalStorageTests/LocalStorageLiveUpdateTestView.swift
+++ b/Tests/UITests/TestApp/LocalStorageTests/LocalStorageLiveUpdateTestView.swift
@@ -38,6 +38,11 @@ struct RowView: View {
     @LocalStorageEntry(.number) private var number
     
     var body: some View {
-        LabeledContent("number", value: number.map(String.init) ?? "–")
+        LabeledContent("Number", value: number.map(String.init) ?? "–")
+        Button("Double Number") {
+            if let number {
+                self.number = number * 2
+            }
+        }
     }
 }

--- a/Tests/UITests/TestApp/LocalStorageTests/LocalStorageLiveUpdateTestView.swift
+++ b/Tests/UITests/TestApp/LocalStorageTests/LocalStorageLiveUpdateTestView.swift
@@ -11,12 +11,12 @@ import SpeziLocalStorage
 import SwiftUI
 
 
-extension LocalStorageKeys {
+extension LocalStorageKeys { // swiftlint:disable:this file_types_order
     static let number = LocalStorageKey<Int>("number")
 }
 
 
-struct LocalStorageLiveUpdateTestView: View {
+struct LocalStorageLiveUpdateTestView: View { // swiftlint:disable:this file_types_order
     @Environment(LocalStorage.self) private var localStorage
     
     var body: some View {
@@ -25,7 +25,7 @@ struct LocalStorageLiveUpdateTestView: View {
             Section {
                 ForEach(0..<5) { number in
                     Button("\(number)") {
-                        try! localStorage.store(number, for: .number)
+                        try? localStorage.store(number, for: .number)
                     }
                 }
             }
@@ -35,11 +35,9 @@ struct LocalStorageLiveUpdateTestView: View {
 
 
 struct RowView: View {
-    @LocalStorageEntry(.number)
-    private var number
+    @LocalStorageEntry(.number) private var number
     
     var body: some View {
         LabeledContent("number", value: number.map(String.init) ?? "–")
     }
 }
-

--- a/Tests/UITests/TestApp/LocalStorageTests/LocalStorageLiveUpdateTestView.swift
+++ b/Tests/UITests/TestApp/LocalStorageTests/LocalStorageLiveUpdateTestView.swift
@@ -1,0 +1,45 @@
+//
+// This source file is part of the Stanford Spezi open-source project
+//
+// SPDX-FileCopyrightText: 2025 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+
+import SpeziLocalStorage
+import SwiftUI
+
+
+extension LocalStorageKeys {
+    static let number = LocalStorageKey<Int>("number")
+}
+
+
+struct LocalStorageLiveUpdateTestView: View {
+    @Environment(LocalStorage.self) private var localStorage
+    
+    var body: some View {
+        Form {
+            RowView()
+            Section {
+                ForEach(0..<5) { number in
+                    Button("\(number)") {
+                        try! localStorage.store(number, for: .number)
+                    }
+                }
+            }
+        }
+    }
+}
+
+
+struct RowView: View {
+    @LocalStorageEntry(.number)
+    private var number
+    
+    var body: some View {
+        LabeledContent("number", value: number.map(String.init) ?? "–")
+    }
+}
+

--- a/Tests/UITests/TestApp/LocalStorageTests/LocalStorageTests.swift
+++ b/Tests/UITests/TestApp/LocalStorageTests/LocalStorageTests.swift
@@ -49,29 +49,34 @@ final class LocalStorageTests: TestAppTestCase {
         guard let publicKey = try secureStorage.retrievePublicKey(forTag: "LocalStorageTests") else {
             throw XCTestFailure()
         }
+        let key = LocalStorageKey<Letter>("letter1", setting: .encrypted(privateKey: privateKey, publicKey: publicKey))
         
         let letter = Letter(greeting: "Hello Paul 👋\(String(repeating: "🚀", count: Int.random(in: 0...10)))")
         
-        try localStorage.store(letter, settings: .encrypted(privateKey: privateKey, publicKey: publicKey))
-        let storedLetter: Letter = try localStorage.read(settings: .encrypted(privateKey: privateKey, publicKey: publicKey))
+        try localStorage.store(letter, for: key)
+        let storedLetter = try localStorage.load(key)
         
         try XCTAssertEqual(letter, storedLetter)
     }
     
+    
     func testLocalStorageTestEncryptedKeychain() throws {
+        let key = LocalStorageKey<Letter>("letter2", setting: .encryptedUsingKeyChain())
         let letter = Letter(greeting: "Hello Paul 👋\(String(repeating: "🚀", count: Int.random(in: 0...10)))")
 
-        try localStorage.store(letter, settings: .encryptedUsingKeyChain())
-        let storedLetter: Letter = try localStorage.read(settings: .encryptedUsingKeyChain())
+        try localStorage.store(letter, for: key)
+        let storedLetter = try localStorage.load(key)
 
         try XCTAssertEqual(letter, storedLetter)
     }
-
+    
+    
     func testLocalStorageTestEncryptedSecureEnclave() throws {
+        let key = LocalStorageKey<Letter>("letter3", setting: .encryptedUsingSecureEnclave())
         let letter = Letter(greeting: "Hello Paul 👋\(String(repeating: "🚀", count: Int.random(in: 0...10)))")
         
-        try localStorage.store(letter, settings: .encryptedUsingSecureEnclave())
-        let storedLetter: Letter = try localStorage.read(settings: .encryptedUsingSecureEnclave())
+        try localStorage.store(letter, for: key)
+        let storedLetter = try localStorage.load(key)
         
         try XCTAssertEqual(letter, storedLetter)
     }

--- a/Tests/UITests/TestApp/LocalStorageTests/LocalStorageTests.swift
+++ b/Tests/UITests/TestApp/LocalStorageTests/LocalStorageTests.swift
@@ -66,7 +66,7 @@ final class LocalStorageTests: TestAppTestCase {
 
         try localStorage.store(letter, for: key)
         let storedLetter = try localStorage.load(key)
-
+        
         try XCTAssertEqual(letter, storedLetter)
     }
     

--- a/Tests/UITests/TestApp/SpeziStorageTests.swift
+++ b/Tests/UITests/TestApp/SpeziStorageTests.swift
@@ -12,6 +12,7 @@ import XCTestApp
 
 enum SpeziStorageTests: String, TestAppTests {
     case localStorage = "Local Storage"
+    case localStorageLiveUpdate = "Local Storage (Live Update)"
     case secureStorage = "Secure Storage"
     
     
@@ -19,6 +20,8 @@ enum SpeziStorageTests: String, TestAppTests {
         switch self {
         case .localStorage:
             LocalStorageTestsView()
+        case .localStorageLiveUpdate:
+            LocalStorageLiveUpdateTestView()
         case .secureStorage:
             SecureStorageTestsView()
         }

--- a/Tests/UITests/TestApp/TestApp.swift
+++ b/Tests/UITests/TestApp/TestApp.swift
@@ -10,6 +10,7 @@ import Spezi
 import SwiftUI
 import XCTestApp
 
+
 @main
 struct UITestsApp: App {
     @ApplicationDelegateAdaptor(TestAppDelegate.self) var appDelegate

--- a/Tests/UITests/TestAppUITests/LocalStorageTests.swift
+++ b/Tests/UITests/TestAppUITests/LocalStorageTests.swift
@@ -22,6 +22,12 @@ final class LocalStorageTests: XCTestCase {
     @MainActor
     func testLocalStorageLiveUpdates() async throws {
         let app = XCUIApplication()
+        
+        func assertNumberEquals(_ expected: Int, file: StaticString = #filePath, line: UInt = #line) {
+            let pred = NSPredicate(format: "label MATCHES %@", "Number.*\(expected)")
+            XCTAssertTrue(app.staticTexts.matching(pred).element.waitForExistence(timeout: 0.5), file: file, line: line)
+        }
+        
         app.launch()
         app.buttons["Local Storage (Live Update)"].tap()
         try await Task.sleep(for: .seconds(0.5))
@@ -29,7 +35,9 @@ final class LocalStorageTests: XCTestCase {
         let numbers = (0..<17).map { _ in Int.random(in: 0..<5) }
         for number in numbers {
             app.buttons["\(number)"].tap()
-            XCTAssertTrue(app.staticTexts.matching(NSPredicate(format: "label MATCHES %@", "number.*\(number)")).element.waitForExistence(timeout: 0.5))
+            assertNumberEquals(number)
         }
+        app.buttons["Double Number"].tap()
+        assertNumberEquals(numbers[numbers.endIndex - 1] * 2)
     }
 }

--- a/Tests/UITests/TestAppUITests/LocalStorageTests.swift
+++ b/Tests/UITests/TestAppUITests/LocalStorageTests.swift
@@ -14,9 +14,22 @@ final class LocalStorageTests: XCTestCase {
     func testLocalStorage() throws {
         let app = XCUIApplication()
         app.launch()
-        
         app.buttons["Local Storage"].tap()
-        
         XCTAssertTrue(app.staticTexts["Passed"].waitForExistence(timeout: 2))
+    }
+    
+    
+    @MainActor
+    func testLocalStorageLiveUpdates() async throws {
+        let app = XCUIApplication()
+        app.launch()
+        app.buttons["Local Storage (Live Update)"].tap()
+        try await Task.sleep(for: .seconds(0.5))
+        
+        let numbers = (0..<17).map { _ in Int.random(in: 0..<5) }
+        for number in numbers {
+            app.buttons["\(number)"].tap()
+            XCTAssertTrue(app.staticTexts.matching(NSPredicate(format: "label MATCHES %@", "number.*\(number)")).element.waitForExistence(timeout: 0.5))
+        }
     }
 }

--- a/Tests/UITests/UITests.xcodeproj/project.pbxproj
+++ b/Tests/UITests/UITests.xcodeproj/project.pbxproj
@@ -20,6 +20,7 @@
 		2F2D338729DE52EA00081B1D /* SpeziStorageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F2D338629DE52EA00081B1D /* SpeziStorageTests.swift */; };
 		2F6D139A28F5F386007C25D6 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 2F6D139928F5F386007C25D6 /* Assets.xcassets */; };
 		2FA7382C290ADFAA007ACEB9 /* TestApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FA7382B290ADFAA007ACEB9 /* TestApp.swift */; };
+		80F81BC22D492A2100F513C3 /* LocalStorageLiveUpdateTestView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80F81BC12D492A2100F513C3 /* LocalStorageLiveUpdateTestView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -47,6 +48,7 @@
 		2F6D13AC28F5F386007C25D6 /* TestAppUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = TestAppUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		2FA7382B290ADFAA007ACEB9 /* TestApp.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestApp.swift; sourceTree = "<group>"; };
 		2FB0758A299DDB9000C0B37F /* TestApp.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = TestApp.xctestplan; sourceTree = "<group>"; };
+		80F81BC12D492A2100F513C3 /* LocalStorageLiveUpdateTestView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalStorageLiveUpdateTestView.swift; sourceTree = "<group>"; };
 		971B61432B9849C100C0B0E2 /* TestApp.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = TestApp.entitlements; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -84,6 +86,7 @@
 			isa = PBXGroup;
 			children = (
 				2F2D336929DE0E7900081B1D /* LocalStorageTestsView.swift */,
+				80F81BC12D492A2100F513C3 /* LocalStorageLiveUpdateTestView.swift */,
 				2F2D336A29DE0E7900081B1D /* LocalStorageTests.swift */,
 			);
 			path = LocalStorageTests;
@@ -255,6 +258,7 @@
 				2FA7382C290ADFAA007ACEB9 /* TestApp.swift in Sources */,
 				2F2D336B29DE0E7900081B1D /* SecureStorageTestsView.swift in Sources */,
 				2F2D336C29DE0E7900081B1D /* SecureStorageTests.swift in Sources */,
+				80F81BC22D492A2100F513C3 /* LocalStorageLiveUpdateTestView.swift in Sources */,
 				2F2D338729DE52EA00081B1D /* SpeziStorageTests.swift in Sources */,
 				2F2D336E29DE0E7900081B1D /* LocalStorageTests.swift in Sources */,
 			);


### PR DESCRIPTION
# add LocalStorageKey; rework LocalStorage API

## :recycle: Current situation & Problem
`LocalStorage` currently identifies entries in the storage via either optional, raw untyped strings, or via the static type of the to-be-stored/loaded value.
While this approach does lead to a nice-looking API, it is problematic for several reasons:
- identifying stored entries using string literals makes it easy to misspel something, or to accidentally use the wrong key
- the fact that there's no static coupling between a key and the type it's used to store/load, means that there's nothing that would prevent someone from acidentally decoding a value into an incorrect type (i.e., a different type than what was encoded into the `LocalStorage` entry)
- the fact that parameters such as e.g. the encoder/decoder or the storage setting, both of which determine how a value is stored/loaded, need to be explicitly specified at both calls to `store()` as well as calls to `read()`, means that it is easy to mismatch these parameters
  - eg: if you use a `PropertyListEncoder` when storing some value into the `LocalStorage`, you need to make sure that you also use the matching `PropertyListDecoder` when reading the stored value.
    - since the current API defaults both the encoder in `store()` and the decoder in `read()` to the `JSONEncoder` (and `JSONDecoder, respectively), makes it too easy to miss the parameter somewhere
  - the same applies to the `storageSetting` parameter: all matching calls to `store()` and `read()` that operate on the same storage key must specify the same storage setting.
    - this is currently not enforced, and with the current API there is no way of enforcing this
- the fact that storage keys are optional (if the key is nil (the default), the unqualified typename of the to-be-stored/loaded type will be used instead) is also likely to lead to unexpected issues:
  - since the unqualified typename doesn't take nesting / access control into account, it can easily happen that two calls to `store()`/`read()` that operate on completely different types (potentially even in completely different modules!) end up operating on the same LocalStorage entry, because the unqualified typename will be the same in both cases

This PR attempts to address these issues, by restructuring and redesigning the `LocalStorage` API:
- Entries in the storage are no longer identified by raw strings which are passed to the `store()`/`load()` calls
- Entries are no longer identified by the typename of the value being stored/loaded
- We instead have a `LocalStorageKey<Value>` type, which are intended to be long-lived objects that are used to access the `LocalStorage`
  - the `LocalStorageKey` encapsulates all information required to store data into the storage / load data from it
  - since every store/load for an entry will use the same `LocalStorageKey` instance, we can ensure that every store/load for the same entry will use matching decoders/encoders, and will use the same storageSetting.
  - it also improves the typing, by associating every storage key with its underlying stored type
  - in order to prevent race conditions and other potential concurrency issues, the `LocalStorageKey` also acts as a read-write lock when accessing the storage entry identified by it
- In addition to these changes, the `LocalStorageKey`-based API also makes it easier to support storing additional currently not supported types, such as e.g. `NSSecureCoding`-compliant types
- **Note** this PR removes support for `CodableWithConfiguration`, which previously was supported but (AFAICT) not used.
- **Note**: `SpeziSecureStorage` is currently untouched; it might make sense to have something similar there as well, but it'd of course require a separate, dedicated key type and would be out-of-scope for this PR.
- This PR also adds a small convenience property wrapper, `@LocalStorageEntry`, which makes it easier to use the `LocalStorage` API from within a SwiftUI View, and is e.g. able to observe a key's value and update the view in response.


## :gear: Release Notes 
- Completely reworked the `LocalStorage` API:
  - Values are stored/loaded via `LocalStorageKey`s, which define an entry in the storage.
  - `LocalStorageKey`s need to explicitly specify their underlying raw keys (a String), and are encouraged to use reverse-DNS-notation in order to avoid collisions


## :books: Documentation
The documentation has been adapted to the new API.

## :white_check_mark: Testing
The tests have been adapted to the new API.


## :pencil: Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
