### PR TITLE
make `LocalStorageSetting` Sendable and Hashable

### DIFF
--- a/Sources/SpeziLocalStorage/LocalStorageSetting.swift
+++ b/Sources/SpeziLocalStorage/LocalStorageSetting.swift
@@ -12,7 +12,7 @@ import SpeziKeychainStorage
 
 
 /// Configure how data is encrypyed, stored, and retrieved.
-public enum LocalStorageSetting {
+public enum LocalStorageSetting: Hashable, Sendable {
     /// Unencrypted
     case unencrypted(excludeFromBackup: Bool = true)
     /// Encrypted using a `eciesEncryptionCofactorX963SHA256AESGCM` key: private key for encryption and a public key for decryption.

--- a/Sources/SpeziLocalStorage/LocalStorageSetting.swift
+++ b/Sources/SpeziLocalStorage/LocalStorageSetting.swift
@@ -66,3 +66,6 @@ public enum LocalStorageSetting: Hashable, Sendable {
         return (privateKey, publicKey)
     }
 }
+
+
+extension SecKey: @retroactive @unchecked Sendable {}

--- a/Sources/SpeziLocalStorage/LocalStorageSetting.swift
+++ b/Sources/SpeziLocalStorage/LocalStorageSetting.swift
@@ -12,7 +12,12 @@ import SpeziKeychainStorage
 
 
 /// Configure how data is encrypyed, stored, and retrieved.
-public enum LocalStorageSetting: Hashable, Sendable {
+public enum LocalStorageSetting: Hashable, @unchecked Sendable {
+    // ^^^SAFETY: The `@unckeched Sendable` conformance above should be fine; we need this because some cases have
+    // `SecKey` associated values, which itself is not Sendable.
+    // But since these `SecKey` objects represent de-facto immutable references to keychain items (private keys),
+    // it should be fine for us to make the type Sendable.
+    
     /// Unencrypted
     case unencrypted(excludeFromBackup: Bool = true)
     /// Encrypted using a `eciesEncryptionCofactorX963SHA256AESGCM` key: private key for encryption and a public key for decryption.
@@ -66,6 +71,3 @@ public enum LocalStorageSetting: Hashable, Sendable {
         return (privateKey, publicKey)
     }
 }
-
-
-extension SecKey: @retroactive @unchecked Sendable {}


### PR DESCRIPTION
# make `LocalStorageSetting` Sendable and Hashable

## :recycle: Current situation & Problem
Follow-up on #30, which forgot to make make `LocalStorageSetting` Sendable and Hashable.


## :gear: Release Notes 
- Made `LocalStorageSetting` Sendable and Hashable.


## :books: Documentation
n/a

## :white_check_mark: Testing
n/a

## :pencil: Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
