### PR TITLE
restore support for `CodableWithConfiguration`

### DIFF
--- a/Sources/SpeziLocalStorage/LocalStorage.swift
+++ b/Sources/SpeziLocalStorage/LocalStorage.swift
@@ -299,12 +299,12 @@ public final class LocalStorage: Module, DefaultInitializable, EnvironmentAccess
     ///     If the closure sets `value` to `nil`, the entry will be removed from the `LocalStorage`.
     ///
     /// - throws: if `transform` throws,
-    public func modify<Value>(
+    public func modify<Value: CodableWithConfiguration>(
         _ key: LocalStorageKey<Value>,
         decodingConfiguration: Value.DecodingConfiguration,
         encodingConfiguration: Value.EncodingConfiguration,
         _ transform: (_ value: inout Value?) throws -> Void
-    ) throws where Value: CodableWithConfiguration {
+    ) throws {
         try key.withWriteLock {
             var value = try readImp(key, context: decodingConfiguration)
             try transform(&value)

--- a/Sources/SpeziLocalStorage/LocalStorage.swift
+++ b/Sources/SpeziLocalStorage/LocalStorage.swift
@@ -25,10 +25,13 @@ import SpeziKeychainStorage
 ///
 /// ### Storing Elements
 /// - ``store(_:for:)``
+/// - ``store(_:for:configuration:)``
 /// - ``modify(_:_:)``
+/// - ``modify(_:decodingConfiguration:encodingConfiguration:_:)``
 ///
 /// ### Loading Elements
 /// - ``load(_:)``
+/// - ``load(_:configuration:)``
 ///
 /// ### Deleting Entries
 /// - ``delete(_:)``
@@ -80,7 +83,27 @@ public final class LocalStorage: Module, DefaultInitializable, EnvironmentAccess
     public func store<Value>(_ value: Value?, for key: LocalStorageKey<Value>) throws {
         try key.withWriteLock {
             if let value {
-                try storeImp(value, for: key)
+                try storeImp(value, for: key, context: ())
+            } else {
+                try deleteImp(key)
+            }
+        }
+    }
+    
+    /// Put a value into the `LocalStorage`.
+    ///
+    /// - parameter value: The value which should be persisted. Passing `nil` will delete the most-recently-stored value.
+    /// - parameter key: The ``LocalStorageKey`` with which the value should be associated.
+    ///
+    /// - Note: This operation will overwrite any previously-stored values for this key.
+    public func store<Value>(
+        _ value: Value?,
+        for key: LocalStorageKey<Value>,
+        configuration: Value.EncodingConfiguration
+    ) throws where Value: EncodableWithConfiguration {
+        try key.withWriteLock {
+            if let value {
+                try storeImp(value, for: key, context: configuration)
             } else {
                 try deleteImp(key)
             }
@@ -89,7 +112,7 @@ public final class LocalStorage: Module, DefaultInitializable, EnvironmentAccess
     
     
     /// - invariant: assumes that the key's write lock is held.
-    private func storeImp<Value>(_ value: Value, for key: LocalStorageKey<Value>) throws {
+    private func storeImp<Value>(_ value: Value, for key: LocalStorageKey<Value>, context: some Any) throws {
         var fileURL = fileURL(for: key)
         let fileExistsAlready = fileManager.fileExists(atPath: fileURL.path)
 
@@ -109,7 +132,7 @@ public final class LocalStorage: Module, DefaultInitializable, EnvironmentAccess
             }
         }
 
-        let data = try key.encode(value)
+        let data = try key.encode(value, context: context)
 
         // Determine if the data should be encrypted or not:
         guard let keys = try key.setting.keys(from: keychainStorage) else {
@@ -143,7 +166,21 @@ public final class LocalStorage: Module, DefaultInitializable, EnvironmentAccess
     /// - returns: The most recent stored value associated with the key; `nil` if no such value exists.
     public func load<Value>(_ key: LocalStorageKey<Value>) throws -> Value? {
         try key.withReadLock {
-            try readImp(key)
+            try readImp(key, context: ())
+        }
+    }
+    
+    /// Load a value from the `LocalStorage`.
+    ///
+    /// - parameter key: The ``LocalStorageKey`` associated with the to-be-retrieved value.
+    /// - parameter configuration: The decoding configuration which should be used when decoding a value.
+    /// - returns: The most recent stored value associated with the key; `nil` if no such value exists.
+    public func load<Value>(
+        _ key: LocalStorageKey<Value>,
+        configuration: Value.DecodingConfiguration
+    ) throws -> Value? where Value: DecodableWithConfiguration {
+        try key.withReadLock {
+            try readImp(key, context: configuration)
         }
     }
     
@@ -157,7 +194,7 @@ public final class LocalStorage: Module, DefaultInitializable, EnvironmentAccess
     
     
     /// - invariant: assumes that the key's read lock is held.
-    private func readImp<Value>(_ key: LocalStorageKey<Value>) throws -> Value? {
+    private func readImp<Value>(_ key: LocalStorageKey<Value>, context: some Any) throws -> Value? {
         let fileURL = fileURL(for: key)
         guard fileManager.fileExists(atPath: fileURL.path) else {
             return nil
@@ -166,7 +203,7 @@ public final class LocalStorage: Module, DefaultInitializable, EnvironmentAccess
 
         // Determine if the data should be decrypted or not:
         guard let keys = try key.setting.keys(from: keychainStorage) else {
-            return try key.decode(data)
+            return try key.decode(from: data, context: context)
         }
 
         guard SecKeyIsAlgorithmSupported(keys.privateKey, .decrypt, encryptionAlgorithm) else {
@@ -178,7 +215,7 @@ public final class LocalStorage: Module, DefaultInitializable, EnvironmentAccess
             throw LocalStorageError.decryptionNotPossible
         }
 
-        return try key.decode(decryptedData)
+        return try key.decode(from: decryptedData, context: context)
     }
     
     
@@ -241,10 +278,38 @@ public final class LocalStorage: Module, DefaultInitializable, EnvironmentAccess
     /// - throws: if `transform` throws,
     public func modify<Value>(_ key: LocalStorageKey<Value>, _ transform: (_ value: inout Value?) throws -> Void) throws {
         try key.withWriteLock {
-            var value = try readImp(key)
+            var value = try readImp(key, context: ())
             try transform(&value)
             if let value {
-                try storeImp(value, for: key)
+                try storeImp(value, for: key, context: ())
+            } else {
+                try deleteImp(key)
+            }
+        }
+    }
+    
+    
+    /// Modify a stored value in place
+    ///
+    /// Use this function to perform an atomic mutation of an entry in the `LocalStorage`.
+    ///
+    /// - parameter key: The ``LocalStorageKey`` whose value should be mutated.
+    /// - parameter transform: A mapping closure, which will be called with the current value stored for `key` (or `nil`, if no value is stored).
+    ///     The value after the closure invocation will be stored into the `LocalStorage`, for the entry identified by `key`.
+    ///     If the closure sets `value` to `nil`, the entry will be removed from the `LocalStorage`.
+    ///
+    /// - throws: if `transform` throws,
+    public func modify<Value>(
+        _ key: LocalStorageKey<Value>,
+        decodingConfiguration: Value.DecodingConfiguration,
+        encodingConfiguration: Value.EncodingConfiguration,
+        _ transform: (_ value: inout Value?) throws -> Void
+    ) throws where Value: CodableWithConfiguration {
+        try key.withWriteLock {
+            var value = try readImp(key, context: decodingConfiguration)
+            try transform(&value)
+            if let value {
+                try storeImp(value, for: key, context: encodingConfiguration)
             } else {
                 try deleteImp(key)
             }

--- a/Sources/SpeziLocalStorage/LocalStorage.swift
+++ b/Sources/SpeziLocalStorage/LocalStorage.swift
@@ -83,7 +83,7 @@ public final class LocalStorage: Module, DefaultInitializable, EnvironmentAccess
     public func store<Value>(_ value: Value?, for key: LocalStorageKey<Value>) throws {
         try key.withWriteLock {
             if let value {
-                try storeImp(value, for: key, context: ())
+                try storeImp(value, for: key, context: Void?.none)
             } else {
                 try deleteImp(key)
             }
@@ -166,7 +166,7 @@ public final class LocalStorage: Module, DefaultInitializable, EnvironmentAccess
     /// - returns: The most recent stored value associated with the key; `nil` if no such value exists.
     public func load<Value>(_ key: LocalStorageKey<Value>) throws -> Value? {
         try key.withReadLock {
-            try readImp(key, context: ())
+            try readImp(key, context: Void?.none)
         }
     }
     
@@ -278,10 +278,10 @@ public final class LocalStorage: Module, DefaultInitializable, EnvironmentAccess
     /// - throws: if `transform` throws,
     public func modify<Value>(_ key: LocalStorageKey<Value>, _ transform: (_ value: inout Value?) throws -> Void) throws {
         try key.withWriteLock {
-            var value = try readImp(key, context: ())
+            var value = try readImp(key, context: Void?.none)
             try transform(&value)
             if let value {
-                try storeImp(value, for: key, context: ())
+                try storeImp(value, for: key, context: Void?.none)
             } else {
                 try deleteImp(key)
             }

--- a/Sources/SpeziLocalStorage/LocalStorageKey.swift
+++ b/Sources/SpeziLocalStorage/LocalStorageKey.swift
@@ -176,6 +176,8 @@ extension LocalStorageKey { // swiftlint:disable:this file_types_order
             if let value = value as? any Encodable {
                 return try encoder.encode(value)
             }
+            // should be unreachable, since this initializer is only used by initializers which themselves
+            // require `Value` be either `Encodable`, or `EncodableWithConfiguration`, or both.
             preconditionFailure("Input type ('\(Value.self)') is neither \((any Encodable).self) nor \((any EncodableWithConfiguration).self)")
         } decode: { (data: Data, context: Any?) in
             if let type = Value.self as? any DecodableWithConfiguration.Type {
@@ -196,6 +198,8 @@ extension LocalStorageKey { // swiftlint:disable:this file_types_order
                 // `Decodable` protocol.
                 return try decoder.decode(type, from: data) as! Value? // swiftlint:disable:this force_cast
             }
+            // should be unreachable, since this initializer is only used by initializers which themselves
+            // require `Value` be either `Decodable`, or `DecodableWithConfiguration`, or both.
             preconditionFailure("Input type ('\(Value.self)') is neither \((any Decodable).self) nor \((any DecodableWithConfiguration).self)")
         }
     }

--- a/Sources/SpeziLocalStorage/LocalStorageKey.swift
+++ b/Sources/SpeziLocalStorage/LocalStorageKey.swift
@@ -67,8 +67,8 @@ public class LocalStorageKeys {
 public final class LocalStorageKey<Value>: LocalStorageKeys, @unchecked Sendable {
     let key: String
     let setting: LocalStorageSetting
-    private let encodeImp: @Sendable (Value, Any) throws -> Data
-    private let decodeImp: @Sendable (Data, Any) throws -> Value?
+    private let encodeImp: @Sendable (Value, Any?) throws -> Data
+    private let decodeImp: @Sendable (Data, Any?) throws -> Value?
     private let lock = RWLock()
     private let subject = PassthroughSubject<Value?, Never>()
     
@@ -121,11 +121,17 @@ public final class LocalStorageKey<Value>: LocalStorageKeys, @unchecked Sendable
         subject.send(newValue)
     }
     
-    func encode(_ value: Value, context: some Any) throws -> Data {
+    /// Encodes a `Value` into `Data`.
+    /// - parameter value: the to-be-encoded value
+    /// - parameter context: optional context which should be passed to the encoding operation. This is intended for passing e.g. an encoding configuration. The caller is responsible for ensuring that the passed-in value is compatible with the specific LocalStorageKey's encoding operation.
+    func encode(_ value: Value, context: (some Any)?) throws -> Data {
         try encodeImp(value, context)
     }
     
-    func decode(from data: Data, context: some Any) throws -> Value? {
+    /// Decodes a `Value` from `Data`.
+    /// - parameter data: the to-be-decoded data
+    /// - parameter context: optional context which should be passed to the decoding operation. This is intended for passing e.g. an decoding configuration. The caller is responsible for ensuring that the passed-in value is compatible with the specific LocalStorageKey's decoding operation.
+    func decode(from data: Data, context: (some Any)?) throws -> Value? {
         try decodeImp(data, context)
     }
 }

--- a/Sources/SpeziLocalStorage/LocalStorageKey.swift
+++ b/Sources/SpeziLocalStorage/LocalStorageKey.swift
@@ -144,7 +144,6 @@ extension LocalStorageKey {
     }
     
     /// Creates a Local Storage Key for a `Codable` type, that uses a custom encoder and decoder.
-    /// - Note: When creating a Local Storage Key for a type that is both `Codable` and `CodableWithConfiguration`, the `CodableWithConfiguration` conformance will take predecence.
     @_disfavoredOverload
     public convenience init<E: SpeziFoundation.TopLevelEncoder & Sendable, D: SpeziFoundation.TopLevelDecoder & Sendable>(
         _ key: String,
@@ -160,7 +159,6 @@ extension LocalStorageKey {
     }
     
     /// Creates a Local Storage Key for a `CodableWithConfiguration` type, that uses a custom encoder and decoder.
-    /// - Note: When creating a Local Storage Key for a type that is both `Codable` and `CodableWithConfiguration`, the `CodableWithConfiguration` conformance will take predecence.
     public convenience init<E: SpeziFoundation.TopLevelEncoder & Sendable, D: SpeziFoundation.TopLevelDecoder & Sendable>(
         _ key: String,
         setting: LocalStorageSetting = .default, // swiftlint:disable:this function_default_parameter_at_end
@@ -171,6 +169,28 @@ extension LocalStorageKey {
             try encoder.encode(value, configuration: configuration)
         } decode: { (data, configuration: Value.DecodingConfiguration) in
             try decoder.decode(Value.self, from: data, configuration: configuration)
+        }
+    }
+    
+    /// Creates a Local Storage Key for a type that is both `Codable` and `CodableWithConfiguration`, that uses a custom encoder and decoder.
+    public convenience init<E: SpeziFoundation.TopLevelEncoder & Sendable, D: SpeziFoundation.TopLevelDecoder & Sendable>(
+        _ key: String,
+        setting: LocalStorageSetting = .default, // swiftlint:disable:this function_default_parameter_at_end
+        encoder: E,
+        decoder: D
+    ) where Value: Codable & CodableWithConfiguration, E.Output == Data, D.Input == Data {
+        self.init(key: key, setting: setting) { (value, configuration: Any?) in
+            if let configuration = configuration as? Value.EncodingConfiguration {
+                try encoder.encode(value, configuration: configuration)
+            } else {
+                try encoder.encode(value)
+            }
+        } decode: { (data, configuration: Any?) in
+            if let configuration = configuration as? Value.DecodingConfiguration {
+                try decoder.decode(Value.self, from: data, configuration: configuration)
+            } else {
+                try decoder.decode(Value.self, from: data)
+            }
         }
     }
     

--- a/Sources/SpeziLocalStorage/LocalStorageKey.swift
+++ b/Sources/SpeziLocalStorage/LocalStorageKey.swift
@@ -153,7 +153,8 @@ extension LocalStorageKey {
         }
     }
     
-    /// Creates a Local Storage Key that uses a custom encoder and decoder.
+    /// Creates a Local Storage Key for a `CodableWithConfiguration` type, that uses a custom encoder and decoder.
+    /// - Note: When creating a Local Storage Key for a type that is both `Codable` and `CodableWithConfiguration`, the `CodableWithConfiguration` conformance will take predecence.
     public convenience init<E: SpeziFoundation.TopLevelEncoder & Sendable, D: SpeziFoundation.TopLevelDecoder & Sendable>(
         _ key: String,
         setting: LocalStorageSetting = .default, // swiftlint:disable:this function_default_parameter_at_end

--- a/Sources/SpeziLocalStorage/LocalStorageKey.swift
+++ b/Sources/SpeziLocalStorage/LocalStorageKey.swift
@@ -264,7 +264,7 @@ extension LocalStorageKey {
             } else {
                 preconditionFailure("Invalid context passed to CodableWithConfiguration encoding operation")
             }
-        } decode: { (data, _) in
+        } decode: { data, _ in
             try decoder.decode(Value.self, from: data)
         }
     }

--- a/Tests/SpeziStorageTests/LocalStorageTests.swift
+++ b/Tests/SpeziStorageTests/LocalStorageTests.swift
@@ -213,26 +213,21 @@ final class LocalStorageTests: XCTestCase {
     
     @MainActor
     func testCodableWithConfiguration() throws {
-        struct TestType: Hashable, Codable, CodableWithConfiguration {
+        struct TestType: Hashable, CodableWithConfiguration {
             struct EncodingConfiguration {
                 let multiplicativeFactor: Int
             }
-            
             struct DecodingConfiguration {
                 let multiplicativeFactor: Int
             }
-            
             let value: Int
-            
             init(value: Int) {
                 self.value = value
             }
-            
             init(from decoder: any Decoder, configuration: DecodingConfiguration) throws {
                 let container = try decoder.singleValueContainer()
                 value = try container.decode(Int.self) * configuration.multiplicativeFactor
             }
-            
             func encode(to encoder: any Encoder, configuration: EncodingConfiguration) throws {
                 var container = encoder.singleValueContainer()
                 try container.encode(value / configuration.multiplicativeFactor)
@@ -255,5 +250,53 @@ final class LocalStorageTests: XCTestCase {
         try localStorage.store(inputValue, for: key, configuration: .init(multiplicativeFactor: 2))
         XCTAssertEqual(try String(contentsOf: localStorage.fileURL(for: key), encoding: .utf8), "6")
         XCTAssertEqual(try localStorage.load(key, configuration: .init(multiplicativeFactor: 2)), inputValue)
+    }
+    
+    
+    @MainActor
+    func testCodableWithConfiguration2() throws {
+        struct TestType: Hashable, Codable, CodableWithConfiguration {
+            struct EncodingConfiguration {
+                let multiplicativeFactor: Int
+            }
+            struct DecodingConfiguration {
+                let multiplicativeFactor: Int
+            }
+            let value: Int
+            init(value: Int) {
+                self.value = value
+            }
+            init(from decoder: any Decoder, configuration: DecodingConfiguration) throws {
+                let container = try decoder.container(keyedBy: CodingKeys.self)
+                value = try container.decode(Int.self, forKey: .value) * configuration.multiplicativeFactor
+            }
+            func encode(to encoder: any Encoder, configuration: EncodingConfiguration) throws {
+                var container = encoder.container(keyedBy: CodingKeys.self)
+                try container.encode(value / configuration.multiplicativeFactor, forKey: .value)
+            }
+        }
+        
+        let localStorage = LocalStorage()
+        withDependencyResolution {
+            localStorage
+        }
+        
+        let key = LocalStorageKey<TestType>(
+            "testtestCodableWithConfig",
+            setting: .unencrypted(excludeFromBackup: true),
+            encoder: JSONEncoder(),
+            decoder: JSONDecoder()
+        )
+        
+        let inputValue = TestType(value: 12)
+        try localStorage.store(inputValue, for: key, configuration: .init(multiplicativeFactor: 2))
+        XCTAssertEqual(try String(contentsOf: localStorage.fileURL(for: key), encoding: .utf8), #"{"value":6}"#)
+        XCTAssertEqual(try localStorage.load(key, configuration: .init(multiplicativeFactor: 2)), inputValue)
+        
+        try localStorage.delete(key)
+        
+        try localStorage.store(inputValue, for: key)
+        XCTAssertEqual(try String(contentsOf: localStorage.fileURL(for: key), encoding: .utf8), #"{"value":12}"#)
+        XCTAssertEqual(try localStorage.load(key), inputValue)
     }
 }

--- a/Tests/SpeziStorageTests/LocalStorageTests.swift
+++ b/Tests/SpeziStorageTests/LocalStorageTests.swift
@@ -262,7 +262,7 @@ final class LocalStorageTests: XCTestCase {
             struct DecodingConfiguration {
                 let multiplicativeFactor: Int
             }
-            let value: Int
+            var value: Int
             init(value: Int) {
                 self.value = value
             }
@@ -298,5 +298,17 @@ final class LocalStorageTests: XCTestCase {
         try localStorage.store(inputValue, for: key)
         XCTAssertEqual(try String(contentsOf: localStorage.fileURL(for: key), encoding: .utf8), #"{"value":12}"#)
         XCTAssertEqual(try localStorage.load(key), inputValue)
+        
+        try localStorage.store(inputValue, for: key, configuration: .init(multiplicativeFactor: 2))
+        
+        try localStorage.modify(
+            key,
+            decodingConfiguration: .init(multiplicativeFactor: 2),
+            encodingConfiguration: .init(multiplicativeFactor: 2)
+        ) { value in
+            value?.value += 2
+        }
+        
+        XCTAssertEqual(try localStorage.load(key, configuration: .init(multiplicativeFactor: 2))?.value, 14)
     }
 }


### PR DESCRIPTION
# restore support for `CodableWithConfiguration`

## :recycle: Current situation & Problem
#30 reworked the LocalStorage API and removed support for types that conform to the `CodableWithConfiguration` protocol.
This PR restores support for such types.

The specific way this is implemented is not 100% perfect (along the way, we need to temporarily erase the configuration values to `Any`), but the changes are implemented in a way that the public API can only be used in a way that maintains type safety.

## :gear: Release Notes 
- LocalStorage: Restored support for types conforming to `CodableWithConfiguration`

## :books: Documentation
updated where applicable

## :white_check_mark: Testing
there is a new test to test the new functionality

## :pencil: Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
