### PR TITLE
add `deleteAll(where:)`

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -55,7 +55,7 @@ jobs:
           - name: iOS
             destination: 'platform=iOS Simulator,name=iPhone 17 Pro'
           - name: iPadOS
-            destination: 'platform=iOS Simulator,name=iPad Pro 11-inch (M4)'
+            destination: 'platform=iOS Simulator,name=iPad Pro 11-inch (M5)'
           - name: visionOS
             destination: 'platform=visionOS Simulator,name=Apple Vision Pro'
       fail-fast: false

--- a/Sources/SpeziLocalStorage/LocalStorage.swift
+++ b/Sources/SpeziLocalStorage/LocalStorage.swift
@@ -265,6 +265,19 @@ public final class LocalStorage: Module, DefaultInitializable, EnvironmentAccess
     }
     
     
+    /// Deletes all entries whose key's satisfy the predicate
+    ///
+    /// - Note: This operation is not synchronized with reads or writes on individual storage keys.
+    public func deleteAll(where predicate: (_ rawKey: String) -> Bool) throws {
+        for url in (try? fileManager.contentsOfDirectory(at: localStorageDirectory, includingPropertiesForKeys: nil)) ?? [] {
+            let rawKey = url.deletingPathExtension().lastPathComponent
+            if predicate(rawKey) {
+                try fileManager.removeItem(at: url)
+            }
+        }
+    }
+    
+    
     // MARK: Other
     
     /// Modify a stored value in place


### PR DESCRIPTION
# add `deleteAll(where:)`

## :recycle: Current situation & Problem
This PR adds a `deleteAll(where:)` function to the LocalStorage module.
The purpose of this function is to allow deleting storage entries in situations where the deleting procdeure does not have access to these entries' storage keys (be it bc they're generated dynamically and the total set of potential keys for a domain can't be computed, or simply bc they're held elsewhere in the program).
The specific use case is SpeziSensorKit, which creates one local storage entry (and associated storage key) for each combination of sensor and source device; since only the set of all possible sensors is known, but the set of possible source devices is not, there needs to be a mechamism to simply tell the LocalStorage module "delete all entries that fall into this scope".


## :gear: Release Notes
- LocalStorage: added `deleteAll(where:)`


## :books: Documentation
yes


## :white_check_mark: Testing
*todo*


## :pencil: Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
