### PR TITLE
swift 6.3 support

### DIFF
--- a/Sources/SpeziKeychainStorage/Credentials/KeychainStorage+Credentials.swift
+++ b/Sources/SpeziKeychainStorage/Credentials/KeychainStorage+Credentials.swift
@@ -49,6 +49,7 @@ extension KeychainStorage {
             try deleteCredentials(withUsername: credentials.username, for: tag)
             try store(credentials, for: tag, replaceDuplicates: false)
         } catch {
+            // https://github.com/swiftlang/swift/issues/88220
             throw error
         }
     }

--- a/Sources/SpeziKeychainStorage/Credentials/KeychainStorage+Credentials.swift
+++ b/Sources/SpeziKeychainStorage/Credentials/KeychainStorage+Credentials.swift
@@ -48,6 +48,8 @@ extension KeychainStorage {
         } catch .duplicateItem where replaceDuplicates {
             try deleteCredentials(withUsername: credentials.username, for: tag)
             try store(credentials, for: tag, replaceDuplicates: false)
+        } catch {
+            throw error
         }
     }
     


### PR DESCRIPTION
# swift 6.3 support

## :gear: Release Notes
- fixed: SpeziKeychainStorage would not compile with swift 6.3


## :books: Documentation
n/a


## :white_check_mark: Testing
n/a


## :pencil: Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling in credential storage operations to ensure proper error propagation in edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->